### PR TITLE
Implement graph builder

### DIFF
--- a/src/recommender/graph_builder.py
+++ b/src/recommender/graph_builder.py
@@ -6,13 +6,28 @@ import networkx as nx
 
 def build_graph(rdf_graph: Graph) -> nx.Graph:
     """
-    Converte um RDFLib Graph em um grafo NetworkX não-direcionado.
+    Converte um ``rdflib.Graph`` em um grafo ``networkx`` não-direcionado.
 
     Deve:
-      1. Iterar sobre triplas (s, p, o) em rdf_graph
-      2. Para cada tripla onde p seja
-         - http://ex.org/stream#assiste
-         - http://ex.org/stream#pertenceAGenero
-        adicionar um nó para s e um nó para o, e uma aresta (s, o)
-      3. Retornar o grafo NetworkX resultante
+      1. Iterar sobre triplas ``(s, p, o)`` em ``rdf_graph``;
+      2. Para cada tripla onde ``p`` seja
+         ``http://ex.org/stream#assiste`` ou
+         ``http://ex.org/stream#pertenceAGenero``, adicionar nós para ``s``
+         e ``o`` e uma aresta ``(s, o)``;
+      3. Retornar o grafo ``networkx`` resultante.
     """
+
+    grafo = nx.Graph()
+
+    predicates = [
+        URIRef("http://ex.org/stream#assiste"),
+        URIRef("http://ex.org/stream#pertenceAGenero"),
+    ]
+
+    for predicate_uri in predicates:
+        for s, p, o in rdf_graph.triples((None, predicate_uri, None)):
+            grafo.add_node(s)
+            grafo.add_node(o)
+            grafo.add_edge(s, o)
+
+    return grafo


### PR DESCRIPTION
## Summary
- implement `build_graph` for converting RDF graphs to NetworkX graphs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'rdflib')*

------
https://chatgpt.com/codex/tasks/task_e_686bc27a90f88328b9d732ec2d189efd