### PR TITLE
Implement centrality metric

### DIFF
--- a/src/recommender/features/centrality.py
+++ b/src/recommender/features/centrality.py
@@ -5,17 +5,20 @@ import networkx as nx
 from typing import Dict, Any
 
 def compute_betweenness(graph: nx.Graph) -> Dict[Any, float]:
-    """
-    Recebe um grafo NetworkX e retorna um dicionário
-    mapeando cada nó ao seu valor de centralidade de betweenness.
+    """Calcula a centralidade de betweenness para todos os nós do grafo.
 
-    Parâmetros:
+    Parameters
     ----------
     graph : nx.Graph
-        Grafo não-direcionado cujas arestas valem 1.
+        Grafo não direcionado e não ponderado.
 
-    Retorna:
+    Returns
     -------
     Dict[Any, float]
-        { nó: valor_de_betweenness, ... }
+        Mapeamento ``{nó: valor}`` com a centralidade de betweenness.
     """
+
+    # A função ``nx.betweenness_centrality`` já retorna exatamente o
+    # dicionário necessário com os valores para cada nó. Assim, apenas
+    # delegamos o cálculo para ela.
+    return nx.betweenness_centrality(graph)

--- a/tests/test_centrality.py
+++ b/tests/test_centrality.py
@@ -1,0 +1,13 @@
+import networkx as nx
+import pytest
+from src.recommender.features.centrality import compute_betweenness
+
+
+def test_compute_betweenness_path():
+    g = nx.Graph()
+    g.add_edge(1, 2)
+    g.add_edge(2, 3)
+    result = compute_betweenness(g)
+    assert result[2] == pytest.approx(1.0)
+    assert result[1] == pytest.approx(0.0)
+    assert result[3] == pytest.approx(0.0)


### PR DESCRIPTION
## Summary
- compute betweenness centrality with NetworkX
- test centrality computation on a simple path

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for networkx and rdflib)*

------
https://chatgpt.com/codex/tasks/task_e_686bc510dd7c832890a377e96bc87db2