### PR TITLE
Implement average shortest path calculation

### DIFF
--- a/src/recommender/features/distance.py
+++ b/src/recommender/features/distance.py
@@ -1,0 +1,32 @@
+# arquivo: src/recommender/features/distance.py
+# Python 3
+
+import networkx as nx
+from typing import Dict, Any
+
+
+def compute_avg_shortest_path_length(graph: nx.Graph) -> Dict[Any, float]:
+    """
+    Para cada nó em `graph`, calcula a média das distâncias (caminhos mais curtos)
+    até todos os outros nós alcançáveis.
+
+    Parâmetros
+    ----------
+    graph : nx.Graph
+        Grafo não-direcionado.
+
+    Retorna
+    -------
+    Dict[Any, float]
+        Dicionário { nó: média_das_distâncias, … }.
+    """
+    results: Dict[Any, float] = {}
+    for node in graph.nodes:
+        lengths = nx.single_source_shortest_path_length(graph, node)
+        # remove a distância para o próprio nó
+        distances = [d for target, d in lengths.items() if target != node]
+        if distances:
+            results[node] = sum(distances) / len(distances)
+        else:
+            results[node] = 0.0
+    return results


### PR DESCRIPTION
## Summary
- add `compute_avg_shortest_path_length` function

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_686bc912126483289d92e44090883964