### PR TITLE
Implement generate_recommendations and SurpriseRS

### DIFF
--- a/src/recommender/pipeline.py
+++ b/src/recommender/pipeline.py
@@ -1,0 +1,48 @@
+# arquivo: src/recommender/pipeline.py
+# Python 3
+
+from typing import Any, Dict, List, Tuple
+from rdflib import Graph
+
+from .ontology_loader import load_ontology
+from .graph_builder import build_graph
+from .features.centrality import compute_betweenness
+from .features.distance import compute_avg_shortest_path_length
+from .recommenders.surprise_rs import SurpriseRS
+from .engine import rerank
+
+
+def generate_recommendations(
+    user_id: Any,
+    ratings: Dict[Tuple[Any, Any], float],
+    ontology_path: str,
+    top_n: int = 10,
+    alpha: float = 0.5,
+    beta: float = 0.5,
+) -> List[Any]:
+    """Gera recomendações serendipiosas para um usuário."""
+    # 1. Carrega a ontologia
+    rdf_graph: Graph = load_ontology(ontology_path)
+
+    # 2. Constrói o grafo NetworkX
+    graph_nx = build_graph(rdf_graph)
+
+    # 3. Calcula a novidade (betweenness)
+    novelty = compute_betweenness(graph_nx)
+
+    # 4. Treina o sistema de recomendação
+    rs = SurpriseRS()
+    rs.fit(ratings)
+
+    # 6. Seleciona itens que o usuário ainda não avaliou
+    rated_items = {item for (user, item) in ratings if user == user_id}
+    candidates = [node for node in graph_nx.nodes if node not in rated_items]
+
+    # 5. Obtém relevância prevista para cada candidato
+    relevance = rs.predict(user_id, candidates)
+
+    # 7. Reordena com base em relevância e novidade
+    ordered = rerank(candidates, relevance, novelty, alpha, beta)
+
+    # 8. Retorna somente os ``top_n`` itens
+    return ordered[:top_n]

--- a/src/recommender/recommenders/surprise_rs.py
+++ b/src/recommender/recommenders/surprise_rs.py
@@ -1,0 +1,39 @@
+from typing import Any, Dict, List, Tuple
+
+class SurpriseRS:
+    """Pequena implementação simplificada de um sistema de recomendação.
+
+    Esta classe não utiliza a biblioteca ``surprise`` para evitar depender de
+    pacotes externos durante os testes. O treinamento consiste em armazenar as
+    avaliações fornecidas, esperando que ``ratings`` seja um dicionário no
+    formato ``{(usuario, item): nota}``.
+    """
+
+    def __init__(self) -> None:
+        self.ratings: Dict[Tuple[Any, Any], float] = {}
+        self.global_mean: float = 0.0
+
+    def fit(self, ratings: Dict[Tuple[Any, Any], float]) -> None:
+        """Armazena as avaliações e calcula a média global."""
+        self.ratings = ratings
+        if ratings:
+            self.global_mean = sum(ratings.values()) / len(ratings)
+        else:
+            self.global_mean = 0.0
+
+    def predict(self, user_id: Any, items: List[Any]) -> Dict[Any, float]:
+        """Retorna uma relevância simples para cada item."""
+        # média das notas para cada item considerando todos os usuários
+        item_sum: Dict[Any, float] = {}
+        item_count: Dict[Any, int] = {}
+        for (u, i), r in self.ratings.items():
+            item_sum[i] = item_sum.get(i, 0.0) + r
+            item_count[i] = item_count.get(i, 0) + 1
+
+        relevance: Dict[Any, float] = {}
+        for item in items:
+            if item in item_sum:
+                relevance[item] = item_sum[item] / item_count[item]
+            else:
+                relevance[item] = self.global_mean
+        return relevance


### PR DESCRIPTION
## Summary
- add pipeline module implementing `generate_recommendations`
- provide simple collaborative filter class `SurpriseRS`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_686bd7b3b1fc83289ee477345f44b39b