### PR TITLE
Fix tests imports after refactor

### DIFF
--- a/src/recommender/pipeline.py
+++ b/src/recommender/pipeline.py
@@ -3,9 +3,9 @@ from typing import Any, Dict, List, Tuple
 from rdflib import Graph, URIRef
 from rdflib.namespace import RDF
 
-from ...ontology.ontology_loader import load_ontology
-from .graph_builder    import build_graph
-from .features.distance   import compute_avg_shortest_path_length
+from ontology.build_ontology import load_ontology
+from .graph_builder import build_graph
+from serendipity.distance import compute_avg_shortest_path_length
 from .recommenders.surprise_rs import SurpriseRS
 from .engine import rerank
 

--- a/tests/test_centrality.py
+++ b/tests/test_centrality.py
@@ -1,6 +1,6 @@
 import networkx as nx
 import pytest
-from src.recommender.features.centrality import compute_betweenness
+from serendipity.centrality import compute_betweenness
 
 
 def test_compute_betweenness_path():

--- a/tests/test_distance.py
+++ b/tests/test_distance.py
@@ -1,7 +1,7 @@
 import pytest
 import networkx as nx
 
-from src.recommender.features.distance import compute_avg_shortest_path_length
+from serendipity.distance import compute_avg_shortest_path_length
 
 def test_compute_avg_shortest_path_length_path():
     # Grafo linha: 1–2–3

--- a/tests/test_ontology_loader.py
+++ b/tests/test_ontology_loader.py
@@ -2,7 +2,7 @@ import pytest
 from rdflib import Graph, URIRef
 from rdflib.namespace import RDF, OWL
 
-from ontology.ontology_loader import load_ontology
+from ontology.build_ontology import load_ontology
 
 def test_load_valid_ontology(tmp_path):
     # 1. Cria um arquivo TTL mínimo


### PR DESCRIPTION
## Summary
- fix pipeline imports after module restructuring
- update test imports to point to new modules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_686be65a40ec83288bc7cbd8d690170c