### PR TITLE
Replace Owlready2 with owlrl

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # manipulação de RDF/OWL
 rdflib>=6.0.0
+owlrl>=6.0
 
 # grafo e métricas de rede complexa
 networkx>=2.8


### PR DESCRIPTION
## Summary
- switch ontology reasoning implementation from Owlready2 to owlrl
- add owlrl to requirements

## Testing
- `black ontology/build_ontology.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'networkx')*

------
https://chatgpt.com/codex/tasks/task_e_686c1c7070448328aced8b6da06f4ed0