### PR TITLE
Fix lint and setup packaging

### DIFF
--- a/collaborative_recommender/surprise_rs.py
+++ b/collaborative_recommender/surprise_rs.py
@@ -1,6 +1,7 @@
 # collaborative_recommender/surprise_rs.py
 from typing import Any, Dict, List, Tuple
 
+
 class SurpriseRS:
     """
     Wrapper simplificado que não depende de scikit-surprise.

--- a/content_recommender/query_by_preference.py
+++ b/content_recommender/query_by_preference.py
@@ -2,6 +2,7 @@
 from rdflib import Graph
 from typing import List
 
+
 def query_by_preference(rdf_graph: Graph, user_uri: str) -> List[str]:
     """
     Retorna a lista de filmes que casam com as preferências do usuário,

--- a/pipeline/engine.py
+++ b/pipeline/engine.py
@@ -3,12 +3,13 @@
 
 from typing import List, Dict, Any
 
+
 def rerank(
     candidates: List[Any],
     relevance: Dict[Any, float],
     novelty: Dict[Any, float],
     alpha: float = 0.5,
-    beta:  float = 0.5
+    beta: float = 0.5,
 ) -> List[Any]:
     """
     Reordena uma lista de candidatos por serendipidade:
@@ -34,5 +35,7 @@ def rerank(
     """
     scores = {}
     for item in candidates:
-        scores[item] = alpha * novelty.get(item, 0.0) + beta * relevance.get(item, 0.0)
+        score = alpha * novelty.get(item, 0.0)
+        score += beta * relevance.get(item, 0.0)
+        scores[item] = score
     return sorted(candidates, key=lambda x: scores[x], reverse=True)

--- a/pipeline/generate_recommendations.py
+++ b/pipeline/generate_recommendations.py
@@ -9,8 +9,10 @@ from rdflib import URIRef, Graph
 from rdflib.namespace import RDF
 
 from ontology.build_ontology import build_ontology_graph
+
 # from content_recommender.query_by_preference import query_by_preference
 from collaborative_recommender.surprise_rs import SurpriseRS
+
 # from serendipity.distance import compute_avg_shortest_path_length
 from serendipity.centrality import compute_betweenness
 from .engine import rerank
@@ -24,18 +26,18 @@ def _build_graph(rdf_graph: Graph) -> nx.Graph:
     """Converte um ``rdflib.Graph`` em um grafo ``networkx`` simples.
 
     A implementação anterior considerava apenas as relações ``:assiste`` e
-    ``:pertenceAGenero``.  Nos testes fornecidos, entretanto, os grafos usam
-    outras propriedades como ``:tematica`` e ``:dirigidoPor``.  Para que a
+    ``:pertenceAGenero``. Nos testes fornecidos, entretanto, os grafos usam
+    outras propriedades como ``:tematica`` e ``:dirigidoPor``. Para que a
     métrica de novidade funcione corretamente em todos os cenários de teste,
-    passamos a considerar **todas** as triplas (exceto ``rdf:type``) ao montar o
-    grafo.
+    passamos a considerar **todas** as triplas (exceto ``rdf:type``) ao
+    montar o grafo.
     """
 
     graph = nx.Graph()
 
     for s, p, o in rdf_graph.triples((None, None, None)):
         if p == RDF.type:
-            # "rdf:type" apenas declara classes; não contribui para conectividade
+            # 'rdf:type' apenas declara classes; não contribui para conectividade
             continue
         if not isinstance(o, URIRef):
             # ignoramos valores literais para manter apenas ligações entre nós
@@ -63,8 +65,7 @@ def generate_recommendations(
     # 2. Seleciona TODOS os vídeos (instâncias de :Filme)
     video_class = URIRef(BASE + "Filme")
     candidates = [
-        subj
-        for subj, _, _ in rdf_graph.triples((None, RDF.type, video_class))
+        subj for subj, _, _ in rdf_graph.triples((None, RDF.type, video_class))
     ]
 
     # 3. Treina e prediz relevância colaborativa

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"

--- a/serendipity/centrality.py
+++ b/serendipity/centrality.py
@@ -4,6 +4,7 @@
 import networkx as nx
 from typing import Dict, Any
 
+
 def compute_betweenness(graph: nx.Graph) -> Dict[Any, float]:
     """Calcula a centralidade de betweenness para todos os nós do grafo.
 

--- a/serendipity/distance.py
+++ b/serendipity/distance.py
@@ -5,10 +5,13 @@ import networkx as nx
 from typing import Dict, Any
 
 
-def compute_avg_shortest_path_length(graph: nx.Graph) -> Dict[Any, float]:
-    """
-    Para cada nó em `graph`, calcula a média das distâncias (caminhos mais curtos)
-    até todos os outros nós alcançáveis.
+def compute_avg_shortest_path_length(
+    graph: nx.Graph,
+) -> Dict[Any, float]:
+    """Calcula a média das distâncias (caminhos mais curtos).
+
+    Para cada nó em ``graph`` são consideradas todas as distâncias
+    até os demais nós alcançáveis.
 
     Parâmetros
     ----------

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,7 @@
+from setuptools import setup, find_packages
+
+setup(
+    name="sin5033-grafos",
+    version="0.1.0",
+    packages=find_packages(),
+)

--- a/src/recommender/graph_builder.py
+++ b/src/recommender/graph_builder.py
@@ -4,6 +4,7 @@
 from rdflib import Graph, URIRef
 import networkx as nx
 
+
 def build_graph(rdf_graph: Graph) -> nx.Graph:
     """
     Converte um ``rdflib.Graph`` em um grafo ``networkx`` não-direcionado.

--- a/src/recommender/pipeline.py
+++ b/src/recommender/pipeline.py
@@ -11,13 +11,14 @@ from .engine import rerank
 
 BASE = "http://ex.org/stream#"
 
+
 def generate_recommendations(
     user_id: Any,
     ratings: Dict[Tuple[Any, Any], float],
     ontology_path: str,
     top_n: int = 10,
     alpha: float = 0.5,
-    beta:  float = 0.5,
+    beta: float = 0.5,
 ) -> List[Any]:
     """Gera recomendações serendipiosas para um usuário."""
 
@@ -27,7 +28,8 @@ def generate_recommendations(
     # 2. Constrói o grafo NetworkX
     graph_nx = build_graph(rdf_graph)
 
-    # 3. Identifica apenas as instâncias de vídeo (filtrando por rdf:type :Video)
+    # 3. Identifica apenas as instâncias de vídeo
+    #    (filtrando por rdf:type :Video)
     video_class = URIRef(BASE + "Video")
     video_nodes = [
         subj for subj, _, _ in rdf_graph.triples((None, RDF.type, video_class))
@@ -35,18 +37,14 @@ def generate_recommendations(
 
     # 4. Calcula a novidade como distância média nos vídeos
     novelty_full = compute_avg_shortest_path_length(graph_nx)
-    novelty = { node: novelty_full.get(node, 0.0) for node in video_nodes }
+    novelty = {node: novelty_full.get(node, 0.0) for node in video_nodes}
 
     # 5. Treina o sistema de recomendação simplificado
     rs = SurpriseRS()
     rs.fit(ratings)
 
-    # 6. Converte os itens já avaliados para URIRefs
-    rated_videos = {
-        URIRef(BASE + item)
-        for (user, item) in ratings
-        if user == user_id
-    }
+    # 6. Converte os itens já avaliados para URIRefs (não usado por ora)
+    _rated_videos = {URIRef(BASE + item) for (user, item) in ratings if user == user_id}
 
     # 7. Define candidatos como vídeos não avaliados
     candidates = video_nodes

--- a/src/recommender/recommenders/surprise_rs.py
+++ b/src/recommender/recommenders/surprise_rs.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, List, Tuple
 
+
 class SurpriseRS:
     """Pequena implementação simplificada de um sistema de recomendação.
 

--- a/tests/test_build_ontology.py
+++ b/tests/test_build_ontology.py
@@ -1,19 +1,22 @@
-import pytest
 from rdflib import URIRef
-from rdflib.namespace import RDF, RDFS
+from rdflib.namespace import RDF
 from ontology.build_ontology import build_ontology_graph
+
 
 def test_infers_subclasses_via_owlrl(tmp_path):
     # 1. Cria um OWL simples com rdfs:subClassOf
     owl = tmp_path / "test.owl"
-    owl.write_text("""
+    owl.write_text(
+        """
     @prefix : <http://ex.org/stream#> .
     @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
     :Filme        a rdfs:Class .
     :Documentario a rdfs:Class ; rdfs:subClassOf :Filme .
     :doc1         a :Documentario .
-    """, encoding="utf-8")
+    """,
+        encoding="utf-8",
+    )
 
     # 2. Gera o grafo com inferências OWL-RL
     g = build_ontology_graph(str(owl))

--- a/tests/test_distance.py
+++ b/tests/test_distance.py
@@ -3,6 +3,7 @@ import networkx as nx
 
 from serendipity.distance import compute_avg_shortest_path_length
 
+
 def test_compute_avg_shortest_path_length_path():
     # Grafo linha: 1–2–3
     G = nx.path_graph([1, 2, 3])

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,18 +1,33 @@
-import pytest
 from pipeline.engine import rerank
+
 
 def test_rerank_basic():
     candidates = [1, 2]
     relevance = {1: 0.9, 2: 0.1}
-    novelty   = {1: 0.2, 2: 0.8}
+    novelty = {1: 0.2, 2: 0.8}
     # com alpha=0.5, beta=0.5: scores = {1:0.55, 2:0.45}
-    assert rerank(candidates, relevance, novelty, alpha=0.5, beta=0.5) == [1, 2]
+    assert rerank(
+        candidates,
+        relevance,
+        novelty,
+        alpha=0.5,
+        beta=0.5,
+    ) == [1, 2]
+
 
 def test_rerank_extreme_weights():
-    candidates = ['a', 'b', 'c']
-    relevance = {'a': 1.0, 'b': 0.0, 'c': 0.5}
-    novelty   = {'a': 0.0, 'b': 1.0, 'c': 0.5}
+    candidates = ["a", "b", "c"]
+    relevance = {"a": 1.0, "b": 0.0, "c": 0.5}
+    novelty = {"a": 0.0, "b": 1.0, "c": 0.5}
     # só novidade (alpha=1, beta=0): b > c > a
-    assert rerank(candidates, relevance, novelty, alpha=1.0, beta=0.0) == ['b', 'c', 'a']
+    assert rerank(candidates, relevance, novelty, alpha=1.0, beta=0.0) == [
+        "b",
+        "c",
+        "a",
+    ]
     # só relevância (alpha=0, beta=1): a > c > b
-    assert rerank(candidates, relevance, novelty, alpha=0.0, beta=1.0) == ['a', 'c', 'b']
+    assert rerank(candidates, relevance, novelty, alpha=0.0, beta=1.0) == [
+        "a",
+        "c",
+        "b",
+    ]

--- a/tests/test_graph_builder.py
+++ b/tests/test_graph_builder.py
@@ -1,6 +1,4 @@
-import pytest
 from rdflib import Graph
-from rdflib.namespace import RDF
 from rdflib import URIRef
 import networkx as nx
 
@@ -27,6 +25,7 @@ TEST_TTL = """\
 :user1   :assiste           :video1 .
 :video1  :pertenceAGenero   :genre1 .
 """
+
 
 def test_build_graph(tmp_path):
     # 1. Cria e carrega o TTL

--- a/tests/test_ontology_loader.py
+++ b/tests/test_ontology_loader.py
@@ -4,10 +4,12 @@ from rdflib.namespace import RDF, OWL
 
 from ontology.build_ontology import load_ontology
 
+
 def test_load_valid_ontology(tmp_path):
     # 1. Cria um arquivo TTL mínimo
     ttl = tmp_path / "test_ontology.ttl"
-    ttl.write_text("""\
+    ttl.write_text(
+        """\
 @prefix : <http://ex.org/stream#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
@@ -15,7 +17,8 @@ def test_load_valid_ontology(tmp_path):
 :Video   rdf:type owl:Class .
 :Usuario rdf:type owl:Class .
 :Genero  rdf:type owl:Class .
-""")
+"""
+    )
 
     # 2. Carrega a ontologia
     g = load_ontology(str(ttl))
@@ -25,20 +28,24 @@ def test_load_valid_ontology(tmp_path):
     base = "http://ex.org/stream#"
     for cls in ("Video", "Usuario", "Genero"):
         uri = URIRef(base + cls)
-        assert any(g.triples((uri, RDF.type, OWL.Class))), \
-            f"Faltou declarar {cls} como owl:Class"
+        assert any(
+            g.triples((uri, RDF.type, OWL.Class))
+        ), f"Faltou declarar {cls} como owl:Class"
+
 
 def test_load_invalid_ontology(tmp_path):
     # 1. Cria um TTL sem a classe Genero
     ttl = tmp_path / "bad_ontology.ttl"
-    ttl.write_text("""\
+    ttl.write_text(
+        """\
 @prefix : <http://ex.org/stream#> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 
 :Video   rdf:type owl:Class .
 :Usuario rdf:type owl:Class .
-""")
+"""
+    )
 
     # 2. Deve falhar indicando falta de Genero
     with pytest.raises(ValueError) as exc:

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,12 +1,3 @@
-from rdflib import Graph
-from rdflib.namespace import RDF
-from rdflib import URIRef
-import pytest
-
-from ontology.build_ontology import build_ontology_graph
-from content_recommender.query_by_preference import query_by_preference
-from collaborative_recommender.surprise_rs import SurpriseRS
-from serendipity.distance import compute_avg_shortest_path_length
 from pipeline.generate_recommendations import generate_recommendations
 
 BASE = "http://ex.org/stream#"
@@ -37,6 +28,7 @@ TTL = """\
         :dirigidoPor :Spielberg .
 """
 
+
 def test_generate_recommendations_basic(tmp_path, monkeypatch):
     path = tmp_path / "ont.ttl"
     path.write_text(TTL)
@@ -44,16 +36,17 @@ def test_generate_recommendations_basic(tmp_path, monkeypatch):
     ratings = {("user1", "videoA"): 5.0}
 
     def fake_predict(self, user_id, items):
-        return { item: (0.0 if item == "videoA" else 1.0) for item in items }
+        return {item: (0.0 if item == "videoA" else 1.0) for item in items}
 
     # Aqui o caminho correto para o seu wrapper simples
     monkeypatch.setattr(
         "collaborative_recommender.surprise_rs.SurpriseRS.predict",
-        fake_predict
+        fake_predict,
     )
 
-    recs = generate_recommendations("user1", ratings, str(path),
-                                   top_n=2, alpha=1.0, beta=0.0)
+    recs = generate_recommendations(
+        "user1", ratings, str(path), top_n=2, alpha=1.0, beta=0.0
+    )
 
     assert recs[0] == "videoB"
     assert recs[1] == "videoA"

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -1,14 +1,6 @@
 # tests/test_pipeline_integration.py
 
-import pytest
-from rdflib import Graph
-from rdflib.namespace import RDF
-from rdflib import URIRef
-from ontology.build_ontology import build_ontology_graph
-from content_recommender.query_by_preference import query_by_preference
 from collaborative_recommender.surprise_rs import SurpriseRS
-from serendipity.distance import compute_avg_shortest_path_length
-from pipeline.engine import rerank
 from pipeline.generate_recommendations import generate_recommendations
 
 BASE = "http://ex.org/stream#"
@@ -43,16 +35,18 @@ TTL = """\
         :dirigidoPor :Nolan .
 """
 
+
 def test_full_pipeline(tmp_path, monkeypatch):
     # 1. Gera o arquivo TTL e o grafo inferido
     f = tmp_path / "full.owl"
     f.write_text(TTL)
     # ratings: só avaliou videoA
-    ratings = { ("user1", "videoA"): 5.0 }
+    ratings = {("user1", "videoA"): 5.0}
 
     # 2. Monkey-patch para forçar relevância
     def fake_predict(self, user_id, items):
-        return { item: (0.0 if item == "videoA" else 1.0) for item in items }
+        return {item: (0.0 if item == "videoA" else 1.0) for item in items}
+
     monkeypatch.setattr(SurpriseRS, "predict", fake_predict)
 
     # 3. Chamamos o pipeline
@@ -62,8 +56,9 @@ def test_full_pipeline(tmp_path, monkeypatch):
         ontology_path=str(f),
         top_n=3,
         alpha=1.0,  # só novelty
-        beta=0.0   # ignora relevance
+        beta=0.0,  # ignora relevance
     )
 
-    # 4. Como só novelty conta, videoB (maior distância) vem antes de C, depois A
+    # 4. Como só novelty conta, videoB (maior distância) vem antes de C
+    #    e depois A
     assert recs == ["videoB", "videoC", "videoA"]

--- a/tests/test_query_by_preference.py
+++ b/tests/test_query_by_preference.py
@@ -1,4 +1,3 @@
-import pytest
 from rdflib import Graph
 from content_recommender.query_by_preference import query_by_preference
 
@@ -15,12 +14,25 @@ TTL = """\
        :prefereDiretor :Nolan .
 
 # Filmes
-:filmeA a :Filme ; :tematica :Acao     ; :temAtor    :DiCaprio ; :temDiretor :Spielberg .
-:filmeB a :Filme ; :tematica :Drama    ; :temAtor    :DiCaprio ; :temDiretor :Nolan      .
-:filmeC a :Filme ; :tematica :Terror   ; :temAtor    :Someone   ; :temDiretor :Nolan      .
-:filmeD a :Filme ; :tematica :Comedia  ; :temAtor    :Someone   ; :temDiretor :Spielberg .
+:filmeA a :Filme ;
+        :tematica :Acao     ;
+        :temAtor    :DiCaprio ;
+        :temDiretor :Spielberg .
+:filmeB a :Filme ;
+        :tematica :Drama    ;
+        :temAtor    :DiCaprio ;
+        :temDiretor :Nolan      .
+:filmeC a :Filme ;
+        :tematica :Terror   ;
+        :temAtor    :Someone   ;
+        :temDiretor :Nolan      .
+:filmeD a :Filme ;
+        :tematica :Comedia  ;
+        :temAtor    :Someone   ;
+        :temDiretor :Spielberg .
 
 """
+
 
 def test_query_by_preference_extended(tmp_path):
     f = tmp_path / "g.ttl"

--- a/tests/test_surprise_rs.py
+++ b/tests/test_surprise_rs.py
@@ -2,6 +2,7 @@
 import pytest
 from collaborative_recommender.surprise_rs import SurpriseRS
 
+
 def test_surprise_rs_basic():
     ratings = {
         ("u1", "i1"): 4.0,


### PR DESCRIPTION
## Summary
- add packaging files so pytest can import modules
- reformat entire repo with black
- clean flake8 errors and adjust long lines
- split long TTL strings in tests

## Testing
- `black --check .`
- `flake8 .`
- `PYTHONPATH=. pytest -q`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_686d06f5897c8328b68f028309301adc