### PR TITLE
Add real dump integration test

### DIFF
--- a/ontology/build_ontology.py
+++ b/ontology/build_ontology.py
@@ -5,6 +5,7 @@ from rdflib.namespace import RDF, OWL
 from owlrl import DeductiveClosure, OWLRL_Semantics
 import gzip
 
+
 def load_ontology(path: str) -> Graph:
     """
     path: caminho para arquivo .ttl ou .owl
@@ -50,9 +51,16 @@ def build_ontology_graph(ontology_path: str) -> Graph:
         g.parse(data=data, format="turtle")
 
     else:
-        # 2) Tenta carregar direto por extensão
-        fmt = "xml" if ontology_path.endswith((".owl", ".rdf", ".xml")) else "turtle"
-        g.parse(ontology_path, format=fmt)
+        # 2) Tenta carregar direto por extensão e faz fallback se precisar
+        ext_xml = (".owl", ".rdf", ".xml")
+        fmt = "xml" if ontology_path.endswith(ext_xml) else "turtle"
+        try:
+            g.parse(ontology_path, format=fmt)
+        except Exception:
+            if fmt == "xml":
+                g.parse(ontology_path, format="turtle")
+            else:
+                raise
 
     # 3) Roda o reasoner OWL RL
     DeductiveClosure(OWLRL_Semantics).expand(g)

--- a/pipeline/generate_recommendations.py
+++ b/pipeline/generate_recommendations.py
@@ -37,7 +37,8 @@ def _build_graph(rdf_graph: Graph) -> nx.Graph:
 
     for s, p, o in rdf_graph.triples((None, None, None)):
         if p == RDF.type:
-            # 'rdf:type' apenas declara classes; não contribui para conectividade
+            # 'rdf:type' apenas declara classes; não contribui para
+            # conectividade
             continue
         if not isinstance(o, URIRef):
             # ignoramos valores literais para manter apenas ligações entre nós
@@ -99,9 +100,8 @@ def generate_recommendations(
     # pode-se cair em todos os filmes:
     if not candidates:
         video_class = URIRef(BASE + "Filme")
-        candidates = [
-            subj for subj, _, _ in rdf_graph.triples((None, RDF.type, video_class))
-        ]
+        triples = rdf_graph.triples((None, RDF.type, video_class))
+        candidates = [subj for subj, _, _ in triples]
 
     # 3. Treina e prediz relevância colaborativa
     rs = SurpriseRS()
@@ -136,7 +136,8 @@ def generate_recommendations(
         from networkx.algorithms import community
 
         communities = {}
-        for cid, comm in enumerate(community.louvain_communities(graph_nx, seed=42)):
+        louvain = community.louvain_communities(graph_nx, seed=42)
+        for cid, comm in enumerate(louvain):
             for node in comm:
                 communities[node] = cid
         novelty_full = compute_hhi(graph_nx, communities)

--- a/serendipity/metrics.py
+++ b/serendipity/metrics.py
@@ -42,7 +42,10 @@ def compute_pagerank(graph: nx.Graph, **kwargs: Any) -> Dict[Any, float]:
     return nx.pagerank(graph, **kwargs)
 
 
-def compute_hhi(graph: nx.Graph, communities: Dict[Any, int]) -> Dict[Any, float]:
+def compute_hhi(
+    graph: nx.Graph,
+    communities: Dict[Any, int],
+) -> Dict[Any, float]:
     """Calcula o índice de Herfindahl-Hirschman (HHI) de cada nó.
 
     Para cada nó, considera a distribuição dos vizinhos entre as

--- a/setup.py
+++ b/setup.py
@@ -3,5 +3,5 @@ from setuptools import setup, find_packages
 setup(
     name="amazing_video_recommender",
     version="0.1.0",
-    packages=find_packages(),            # <— encontra todos os sub-pacotes
+    packages=find_packages(),  # <— encontra todos os sub-pacotes
 )

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+# src package

--- a/src/recommender/pipeline.py
+++ b/src/recommender/pipeline.py
@@ -43,10 +43,7 @@ def generate_recommendations(
     rs = SurpriseRS()
     rs.fit(ratings)
 
-    # 6. Converte os itens já avaliados para URIRefs (não usado por ora)
-    _rated_videos = {URIRef(BASE + item) for (user, item) in ratings if user == user_id}
-
-    # 7. Define candidatos como vídeos não avaliados
+    # 6. Define candidatos como vídeos não avaliados
     candidates = video_nodes
 
     # 8. Obtém relevância prevista (fake_predict será aplicado aqui no teste)

--- a/tests/test_pipeline_integration_real.py
+++ b/tests/test_pipeline_integration_real.py
@@ -1,0 +1,33 @@
+import pytest
+from rdflib import URIRef
+from pipeline.generate_recommendations import generate_recommendations
+
+# teste de integração usando o dump real de filmes
+
+
+@pytest.mark.integration
+def test_generate_recommendations_real_dump():
+    """Executa o pipeline usando o dump real."""
+    # usuário de teste
+    user_id = "user_test"
+    # dicionário de ratings onde o usuário avaliou dois filmes do dump
+    ratings = {
+        (user_id, URIRef("http://www.wikidata.org/entity/Q44578")): 9.0,
+        (user_id, URIRef("http://www.wikidata.org/entity/Q130232")): 9.0,
+    }
+
+    # gera recomendações
+    recs = generate_recommendations(
+        user_id=user_id,
+        ratings=ratings,
+        ontology_path="data/raw/serendipity_films_full.ttl.gz",
+        top_n=5,
+        alpha=1.0,
+        beta=0.0,
+    )
+
+    # retorna lista de strings com tamanho 5
+    assert isinstance(recs, list)
+    assert len(recs) == 5
+    # pelo menos uma recomendação deve ser diferente dos filmes avaliados
+    assert any(r not in {"Q44578", "Q130232"} for r in recs)


### PR DESCRIPTION
## Summary
- add integration test that loads the real serendipity dump and runs `generate_recommendations`
- fix ontology loader to fallback to turtle parsing when extension mismatches
- ensure package imports from `src` work by adding `src/__init__.py`
- clean up long lines and remove unused variable

## Testing
- `black --check .`
- `flake8 .`
- `pytest --maxfail=1 --disable-warnings -q`


------
https://chatgpt.com/codex/tasks/task_e_686ed88758f8832889cd1d4d464562d3