### PR TITLE
Implement new Streamlit UI

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import List, Tuple
+
 import pandas as pd
 import requests
 import streamlit as st
@@ -11,54 +13,53 @@ from pipeline.generate_recommendations import generate_recommendations
 
 DATA_PATH = "data/raw/serendipity_films_full.ttl.gz"
 WIKIDATA_URL = "https://query.wikidata.org/sparql"
+PLACEHOLDER_IMG = "https://placehold.co/200x300?text=Poster"
 
 
 @st.cache_resource
 def load_graph(path: str = DATA_PATH) -> Graph:
-    """Carrega a ontologia inferida do dump local."""
+    """Carrega a ontologia inferida.
+
+    Parâmetros
+    ----------
+    path : str
+        Caminho para o dump local.
+
+    Retorna
+    -------
+    Graph
+        Grafo RDF com inferências.
+    """
+
     return build_ontology_graph(path)
 
 
 @st.cache_data
-def load_catalog(graph: Graph) -> pd.DataFrame:
-    """Extrai todos os filmes do grafo."""
-    q = """
+def load_catalog(_graph: Graph) -> pd.DataFrame:
+    """Lista todos os filmes presentes no grafo.
+
+    Parâmetros
+    ----------
+    _graph : Graph
+        Grafo já carregado.
+
+    Retorna
+    -------
+    pd.DataFrame
+        DataFrame contendo as URIs dos filmes.
+    """
+
+    query = """
     PREFIX ex: <http://ex.org/stream#>
     SELECT DISTINCT ?f WHERE { ?f a ex:Filme . }
     """
-    uris = [str(r.f) for r in graph.query(q)]
-    data = {
-        "Título": [uri.split("/")[-1] for uri in uris],
-        "Ano": ["" for _ in uris],
-        "URI": uris,
-    }
-    return pd.DataFrame(data)
+    uris = [str(r.f) for r in _graph.query(query)]
+    return pd.DataFrame({"uri": uris})
 
 
-def fetch_label(uri: str) -> str:
-    """Obtém o rótulo em inglês para uma URI do Wikidata."""
-    qid = uri.split("/")[-1]
-    query = (
-        f"SELECT ?l WHERE {{ wd:{qid} rdfs:label ?l FILTER(lang(?l)='en') }} LIMIT 1"
-    )
-    try:
-        resp = requests.get(
-            WIKIDATA_URL,
-            params={"query": query},
-            headers={"Accept": "application/sparql-results+json"},
-            timeout=10,
-        )
-        resp.raise_for_status()
-        results = resp.json().get("results", {}).get("bindings", [])
-        if results:
-            return results[0]["l"]["value"]
-    except Exception:
-        pass
-    return qid
+def fetch_label_year(uri: str) -> Tuple[str, str | None]:
+    """Obtém rótulo e ano via Wikidata."""
 
-
-def fetch_label_year(uri: str) -> tuple[str, str | None]:
-    """Retorna título e ano usando o endpoint do Wikidata."""
     qid = uri.split("/")[-1]
     query = f"""
     SELECT ?l ?date WHERE {{
@@ -86,76 +87,126 @@ def fetch_label_year(uri: str) -> tuple[str, str | None]:
     return qid, None
 
 
-def get_details(graph: Graph, uri: str) -> dict[str, list[str]]:
+def fetch_image(uri: str) -> str:
+    """Retorna URL da imagem (P18) do item no Wikidata."""
+
+    qid = uri.split("/")[-1]
+    query = f"SELECT ?img WHERE {{ wd:{qid} wdt:P18 ?img }} LIMIT 1"
+    try:
+        resp = requests.get(
+            WIKIDATA_URL,
+            params={"query": query},
+            headers={"Accept": "application/sparql-results+json"},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        results = resp.json().get("results", {}).get("bindings", [])
+        if results:
+            return results[0]["img"]["value"]
+    except Exception:
+        pass
+    return PLACEHOLDER_IMG
+
+
+def get_details(graph: Graph, uri: str) -> dict[str, List[str]]:
     """Coleta gêneros, diretores e elenco do grafo local."""
+
     base = "http://www.wikidata.org/prop/direct/"
     p_genre = URIRef(base + "P136")
     p_director = URIRef(base + "P57")
     p_cast = URIRef(base + "P161")
 
-    genres = [fetch_label(str(o)) for o in graph.objects(URIRef(uri), p_genre)]
-    directors = [fetch_label(str(o)) for o in graph.objects(URIRef(uri), p_director)]
-    cast = [fetch_label(str(o)) for o in graph.objects(URIRef(uri), p_cast)]
+    # fmt: off
+    genres = [
+        fetch_label_year(str(o))[0]
+        for o in graph.objects(URIRef(uri), p_genre)
+    ]
+    directors = [
+        fetch_label_year(str(o))[0]
+        for o in graph.objects(URIRef(uri), p_director)
+    ]
+    cast = [
+        fetch_label_year(str(o))[0]
+        for o in graph.objects(URIRef(uri), p_cast)
+    ]
+    # fmt: on
     return {"genres": genres, "directors": directors, "cast": cast}
 
 
-# --- Streamlit UI -----------------------------------------------------------
+def _select_uri(uri: str) -> None:
+    """Atualiza a URI escolhida na sessão."""
+
+    st.session_state.selected_uri = uri
+
+
+def _show_row_of_posters(uri_list: List[str]) -> None:
+    """Exibe uma fileira de capas clicáveis."""
+
+    cols = st.columns(len(uri_list))
+    for col, uri in zip(cols, uri_list):
+        title, _ = fetch_label_year(uri)
+        img = fetch_image(uri)
+        col.image(img, use_column_width=True)
+        col.button(
+            title,
+            key=uri,
+            on_click=_select_uri,
+            args=(uri,),
+            use_container_width=True,
+        )
+
+
+# --- Configuração inicial ---
 
 graph = load_graph()
 catalog_df = load_catalog(graph)
 
+if "selected_uri" not in st.session_state:
+    st.session_state.selected_uri = None
+
 st.title("Amazing Video Recommender")
-section = st.sidebar.radio("Navegação", ["📺 Catálogo", "🎲 Detalhes & Recomendações"])
 
-if section == "📺 Catálogo":
-    search = st.text_input("Filtrar por título")
-    filtered = (
-        catalog_df[catalog_df["Título"].str.contains(search, case=False)]
-        if search
-        else catalog_df
+search = st.text_input("🔍 Buscar filme")
+filtered = (
+    catalog_df[catalog_df["uri"].str.contains(search, case=False)]
+    if search
+    else catalog_df
+)
+
+uris = filtered["uri"].tolist()
+# fmt: off
+for i in range(0, len(uris), 5):
+    _show_row_of_posters(uris[i:i + 5])
+# fmt: on
+
+selected_uri = st.session_state.get("selected_uri")
+if selected_uri:
+    title, year = fetch_label_year(selected_uri)
+    st.header(f"{title} ({year or 'N/A'})")
+    details = get_details(graph, selected_uri)
+    if details["genres"]:
+        st.markdown("**Gêneros:** " + ", ".join(details["genres"]))
+    if details["directors"]:
+        st.markdown("**Diretores:** " + ", ".join(details["directors"]))
+    if details["cast"]:
+        st.markdown("**Elenco:** " + ", ".join(details["cast"]))
+
+    st.subheader("Você pode gostar também de...")
+    logical = recommend_logical(selected_uri, DATA_PATH)
+    _show_row_of_posters(logical)
+
+    st.subheader("Ou você pode se surpreender com...")
+    serendip = generate_recommendations(
+        "user",
+        {("user", URIRef(selected_uri)): 5.0},
+        DATA_PATH,
+        top_n=5,
+        alpha=1.0,
+        beta=0.0,
     )
-    st.dataframe(filtered)
-    selection = st.selectbox("Selecione um filme", filtered["URI"])
-    st.session_state["selected_film"] = selection
-
-else:
-    uri = st.session_state.get("selected_film")
-    if not uri:
-        st.info("Selecione um filme na aba Catálogo.")
-    else:
-        title, year = fetch_label_year(uri)
-        st.subheader(f"{title} ({year or 'N/A'})")
-        details = get_details(graph, uri)
-        st.markdown("**Gêneros:** " + ", ".join(details["genres"]) or "N/A")
-        st.markdown("**Diretor(es):** " + ", ".join(details["directors"]) or "N/A")
-        st.markdown("**Elenco:** " + ", ".join(details["cast"]) or "N/A")
-
-        tab1, tab2 = st.tabs(["Recomendação Lógica", "Serendipidade"])
-
-        with tab1:
-            if st.button("Gerar", key="logical"):
-                with st.spinner("Carregando recomendações..."):
-                    try:
-                        recs = recommend_logical(uri, DATA_PATH)
-                        for r in recs:
-                            st.markdown(f"- [{r.split('/')[-1]}]({r})")
-                    except Exception as exc:
-                        st.error(str(exc))
-        with tab2:
-            if st.button("Gerar", key="serendipity"):
-                with st.spinner("Carregando recomendações..."):
-                    try:
-                        ratings = {("user", URIRef(uri)): 5.0}
-                        recs = generate_recommendations(
-                            user_id="user",
-                            ratings=ratings,
-                            ontology_path=DATA_PATH,
-                            top_n=5,
-                            alpha=1.0,
-                            beta=0.0,
-                        )
-                        for qid in recs:
-                            url = f"http://www.wikidata.org/entity/{qid}"
-                            st.markdown(f"- [{qid}]({url})")
-                    except Exception as exc:
-                        st.error(str(exc))
+    # fmt: off
+    serendip_uris = [
+        f"http://www.wikidata.org/entity/{qid}" for qid in serendip
+    ]
+    # fmt: on
+    _show_row_of_posters(serendip_uris)

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -1,0 +1,45 @@
+import pytest
+from rdflib import Graph
+
+import importlib.util
+import pathlib
+
+MODULE_PATH = pathlib.Path(__file__).resolve().parents[1] / "streamlit_app.py"
+spec = importlib.util.spec_from_file_location("_app", MODULE_PATH)
+module = importlib.util.module_from_spec(spec)
+with open(MODULE_PATH, "r", encoding="utf-8") as fh:
+    code = fh.read().split("# --- Configuração inicial ---", maxsplit=1)[0]
+exec(code, module.__dict__)
+
+load_graph = module.load_graph
+load_catalog = module.load_catalog
+
+TTL = """
+@prefix ex: <http://ex.org/stream#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+ex:f1 a ex:Filme .
+ex:f2 a ex:Filme .
+"""
+
+
+def test_load_graph_and_catalog(tmp_path):
+    # Arrange
+    f = tmp_path / "g.ttl"
+    f.write_text(TTL, encoding="utf-8")
+
+    # Act
+    g = load_graph(path=str(f))
+    df = load_catalog(g)
+
+    # Assert
+    assert isinstance(g, Graph)
+    assert set(df["uri"]) == {
+        "http://ex.org/stream#f1",
+        "http://ex.org/stream#f2",
+    }
+
+
+def test_load_graph_invalid_path():
+    with pytest.raises(Exception):
+        load_graph(path="no_such_file.ttl")


### PR DESCRIPTION
## Summary
- rewrite `streamlit_app.py` with single-page layout, caching and poster grid
- remove query param navigation and use session state
- add helper for selecting posters via buttons

## Testing
- `black --check streamlit_app.py tests/test_streamlit_app.py`
- `flake8 streamlit_app.py tests/test_streamlit_app.py`
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686fc50dc1b48328a2be6ebc0b047d50