### PR TITLE
refactor: update poster display and caching

### DIFF
--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -30,7 +30,8 @@ def test_load_graph_and_catalog(tmp_path):
 
     # Act
     g = load_graph(path=str(f))
-    df = load_catalog(g)
+    module._graph = g
+    df = load_catalog()
 
     # Assert
     assert isinstance(g, Graph)


### PR DESCRIPTION
## Summary
- cache `fetch_label_year` and `fetch_image`
- simplify poster rendering with `st.image` and `st.button`
- manage selected film via session state
- adjust catalog loader signature
- update tests for new loader usage

## Testing
- `black --check .`
- `flake8 .` *(fails: F401, E501)*
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_686ffbae225c8328a851693b06230c5a