### PR TITLE
Add Flask microservice interface

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from typing import List, Tuple, Dict, Optional
+
+import pandas as pd
+import requests
+from flask import Flask, render_template, request
+from rdflib import Graph, URIRef
+
+from ontology.build_ontology import build_ontology_graph
+from pipeline.generate_logical_recommendations import recommend_logical
+from pipeline.generate_recommendations import generate_recommendations
+
+DATA_PATH = "data/raw/serendipity_films_full.ttl.gz"
+WIKIDATA_URL = "https://query.wikidata.org/sparql"
+PLACEHOLDER_IMG = "https://placehold.co/200x300?text=Poster"
+
+app = Flask(__name__)
+
+graph: Graph
+catalog_df: pd.DataFrame
+
+
+def load_graph(path: str = DATA_PATH) -> Graph:
+    """Carrega a ontologia inferida.
+
+    Parameters
+    ----------
+    path : str
+        Caminho para o arquivo TTL/OWL.
+
+    Returns
+    -------
+    Graph
+        Grafo RDF com inferências.
+    """
+    return build_ontology_graph(path)
+
+
+def load_catalog() -> pd.DataFrame:
+    """Lista todos os filmes presentes no grafo global."""
+    query = """
+    PREFIX ex: <http://ex.org/stream#>
+    SELECT DISTINCT ?f WHERE { ?f a ex:Filme . }
+    """
+    uris = [str(r.f) for r in graph.query(query)]
+    return pd.DataFrame({"uri": uris})
+
+
+def fetch_label_year(uri: str) -> Tuple[str, Optional[str]]:
+    """Obtém rótulo e ano via Wikidata."""
+    qid = uri.split("/")[-1]
+    query = f"""
+    SELECT ?l ?date WHERE {{
+      OPTIONAL {{ wd:{qid} rdfs:label ?l FILTER(lang(?l)='en') }}
+      OPTIONAL {{ wd:{qid} wdt:P577 ?date }}
+    }} LIMIT 1
+    """
+    try:
+        resp = requests.get(
+            WIKIDATA_URL,
+            params={"query": query},
+            headers={"Accept": "application/sparql-results+json"},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        bindings = resp.json().get("results", {}).get("bindings", [])
+        if bindings:
+            b = bindings[0]
+            label = b.get("l", {}).get("value", qid)
+            date = b.get("date", {}).get("value")
+            year = date[:4] if date else None
+            return label, year
+    except Exception:
+        pass
+    return qid, None
+
+
+def fetch_image(uri: str) -> str:
+    """Retorna URL da imagem (P18) do item no Wikidata."""
+    qid = uri.split("/")[-1]
+    query = f"SELECT ?img WHERE {{ wd:{qid} wdt:P18 ?img }} LIMIT 1"
+    try:
+        resp = requests.get(
+            WIKIDATA_URL,
+            params={"query": query},
+            headers={"Accept": "application/sparql-results+json"},
+            timeout=10,
+        )
+        resp.raise_for_status()
+        results = resp.json().get("results", {}).get("bindings", [])
+        if results:
+            return results[0]["img"]["value"]
+    except Exception:
+        pass
+    return PLACEHOLDER_IMG
+
+
+def get_details(graph: Graph, uri: str) -> Dict[str, List[str]]:
+    """Coleta gêneros, diretores e elenco do grafo local."""
+    base = "http://www.wikidata.org/prop/direct/"
+    p_genre = URIRef(base + "P136")
+    p_director = URIRef(base + "P57")
+    p_cast = URIRef(base + "P161")
+
+    # fmt: off
+    genres = [
+        fetch_label_year(str(o))[0]
+        for o in graph.objects(URIRef(uri), p_genre)
+    ]
+    directors = [
+        fetch_label_year(str(o))[0]
+        for o in graph.objects(URIRef(uri), p_director)
+    ]
+    cast = [
+        fetch_label_year(str(o))[0]
+        for o in graph.objects(URIRef(uri), p_cast)
+    ]
+    # fmt: on
+    return {"genres": genres, "directors": directors, "cast": cast}
+
+
+@app.route("/")
+def index():
+    q = request.args.get("q", "")
+    selected = request.args.get("selected")
+
+    filtered = catalog_df
+    if q:
+        filtered = catalog_df[catalog_df["uri"].str.contains(q, case=False)]
+
+    uris = filtered["uri"].tolist()
+    posters = [(u, fetch_image(u), fetch_label_year(u)[0]) for u in uris]
+
+    title = year = None
+    details = {"genres": [], "directors": [], "cast": []}
+    recs_log: List[Tuple[str, str, str]] = []
+    recs_ser: List[Tuple[str, str, str]] = []
+
+    if selected:
+        title, year = fetch_label_year(selected)
+        details = get_details(graph, selected)
+
+        logical = recommend_logical(selected, DATA_PATH)
+        # fmt: off
+        recs_log = [
+            (u, fetch_image(u), fetch_label_year(u)[0])
+            for u in logical
+        ]
+        # fmt: on
+
+        serendip = generate_recommendations(
+            "user",
+            {("user", URIRef(selected)): 5.0},
+            DATA_PATH,
+            top_n=5,
+            alpha=1.0,
+            beta=0.0,
+        )
+        # fmt: off
+        ser_uris = [
+            f"http://www.wikidata.org/entity/{qid}"
+            for qid in serendip
+        ]
+        # fmt: on
+        # fmt: off
+        recs_ser = [
+            (u, fetch_image(u), fetch_label_year(u)[0])
+            for u in ser_uris
+        ]
+        # fmt: on
+
+    return render_template(
+        "index.html",
+        posters=posters,
+        q=q,
+        selected=selected,
+        title=title,
+        year=year,
+        genres=details["genres"],
+        directors=details["directors"],
+        cast=details["cast"],
+        recs_log=recs_log,
+        recs_ser=recs_ser,
+    )
+
+
+def _init_app() -> None:
+    global graph, catalog_df
+    graph = load_graph()
+    catalog_df = load_catalog()
+
+
+_init_app()
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/pipeline/generate_logical_recommendations.py
+++ b/pipeline/generate_logical_recommendations.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 from typing import List
-from rdflib import Graph, URIRef
-from rdflib.namespace import RDF
+from rdflib import Graph
 import gzip
 
 
@@ -18,7 +17,11 @@ def _load_graph(path: str) -> Graph:
     return g
 
 
-def recommend_logical(uri: str, ontology_path: str, top_n: int = 5) -> List[str]:
+def recommend_logical(
+    uri: str,
+    ontology_path: str,
+    top_n: int = 5,
+) -> List[str]:
     """Retorna filmes logicamente relacionados.
 
     Parameters

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ SPARQLWrapper>=2.0
 
 # front-end interativo
 streamlit>=1.18
+Flask>=2.0
 
 # plotting de métricas e resultados
 matplotlib>=3.5

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Amazing Video Recommender</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css">
+    <style>
+      .poster { width: 20%; padding: 10px; }
+      .poster img { width: 100%; height: auto; }
+    </style>
+  </head>
+  <body class="container py-4">
+    <form method="get" action="/" class="mb-4">
+      <div class="input-group">
+        <input type="text" class="form-control" name="q" placeholder="Buscar filme" value="{{ q }}">
+        <button class="btn btn-primary" type="submit">Buscar</button>
+      </div>
+    </form>
+
+    <div class="d-flex flex-wrap">
+      {% for uri, img, label in posters %}
+      <div class="poster text-center">
+        <a href="/?selected={{ uri }}{% if q %}&q={{ q }}{% endif %}">
+          <img src="{{ img }}" alt="{{ label }}">
+          <p>{{ label }}</p>
+        </a>
+      </div>
+      {% endfor %}
+    </div>
+
+    {% if selected %}
+    <div id="details" class="mt-4">
+      <h2>{{ title }}{% if year %} ({{ year }}){% endif %}</h2>
+      <p><strong>Gêneros:</strong> {{ genres|join(', ') }}</p>
+      <p><strong>Diretores:</strong> {{ directors|join(', ') }}</p>
+      <p><strong>Elenco:</strong> {{ cast|join(', ') }}</p>
+    </div>
+
+    <h3>Você pode gostar também de…</h3>
+    <div class="row">
+      {% for uri, img, label in recs_log %}
+      <div class="col poster text-center">
+        <img src="{{ img }}" alt="{{ label }}">
+        <p>{{ label }}</p>
+      </div>
+      {% endfor %}
+    </div>
+
+    <h3>Ou se surpreenda com…</h3>
+    <div class="row">
+      {% for uri, img, label in recs_ser %}
+      <div class="col poster text-center">
+        <img src="{{ img }}" alt="{{ label }}">
+        <p>{{ label }}</p>
+      </div>
+      {% endfor %}
+    </div>
+    {% endif %}
+  </body>
+</html>

--- a/tests/test_flask_app.py
+++ b/tests/test_flask_app.py
@@ -1,0 +1,44 @@
+import importlib.util
+import pathlib
+
+from rdflib import Graph
+
+MODULE_PATH = pathlib.Path(__file__).resolve().parents[1] / "app.py"
+spec = importlib.util.spec_from_file_location("flask_app", MODULE_PATH)
+module = importlib.util.module_from_spec(spec)
+with open(MODULE_PATH, "r", encoding="utf-8") as fh:
+    code = fh.read().split("\n_init_app()", maxsplit=1)[0]
+exec(code, module.__dict__)
+
+load_graph = module.load_graph
+load_catalog = module.load_catalog
+
+TTL = """
+@prefix ex: <http://ex.org/stream#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+ex:f1 a ex:Filme .
+ex:f2 a ex:Filme .
+"""
+
+
+def test_load_graph_and_catalog(tmp_path):
+    f = tmp_path / "g.ttl"
+    f.write_text(TTL, encoding="utf-8")
+
+    g = load_graph(path=str(f))
+    module.graph = g
+    df = load_catalog()
+
+    assert isinstance(g, Graph)
+    assert set(df["uri"]) == {
+        "http://ex.org/stream#f1",
+        "http://ex.org/stream#f2",
+    }
+
+
+def test_load_graph_invalid_path():
+    import pytest
+
+    with pytest.raises(Exception):
+        load_graph(path="no_such_file.ttl")

--- a/tests/test_generate_logical_recommendations.py
+++ b/tests/test_generate_logical_recommendations.py
@@ -21,7 +21,11 @@ def test_recommend_logical_basic(tmp_path):
     f = tmp_path / "graph.ttl"
     f.write_text(TTL)
 
-    recs = recommend_logical("http://ex.org/stream#f1", ontology_path=str(f), top_n=5)
+    recs = recommend_logical(
+        "http://ex.org/stream#f1",
+        ontology_path=str(f),
+        top_n=5,
+    )
     assert "http://ex.org/stream#f2" in recs
     assert "http://ex.org/stream#f1" not in recs
 
@@ -30,10 +34,17 @@ def test_recommend_logical_no_match(tmp_path):
     f = tmp_path / "graph.ttl"
     f.write_text(TTL)
 
-    recs = recommend_logical("http://ex.org/stream#f3", ontology_path=str(f), top_n=5)
+    recs = recommend_logical(
+        "http://ex.org/stream#f3",
+        ontology_path=str(f),
+        top_n=5,
+    )
     assert recs == []
 
 
 def test_recommend_logical_invalid_path():
     with pytest.raises(Exception):
-        recommend_logical("http://ex.org/stream#f1", ontology_path="no_file.ttl")
+        recommend_logical(
+            "http://ex.org/stream#f1",
+            ontology_path="no_file.ttl",
+        )


### PR DESCRIPTION
## Summary
- implement new Flask web service in `app.py`
- render posters, details and recommendations with Jinja template
- add Bootstrap-based `templates/index.html`
- provide tests for helper functions in the Flask app
- include Flask in requirements
- adjust code style for flake8 compliance

## Testing
- `black --check .`
- `flake8 .`
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_68700356d95083288a3d0367f18e2724