### PR TITLE
Implement as_rdflib_graph loader

### DIFF
--- a/ontology/as_rdflib_graph.py
+++ b/ontology/as_rdflib_graph.py
@@ -1,0 +1,23 @@
+"""Utilitários para criação de grafos RDFLib."""
+
+from rdflib import Graph
+
+
+def as_rdflib_graph(path: str) -> Graph:
+    """Carrega um arquivo OWL ou TTL em um :class:`rdflib.Graph`.
+
+    Parameters
+    ----------
+    path : str
+        Caminho para um arquivo ``.ttl`` ou ``.owl``.
+
+    Returns
+    -------
+    Graph
+        Grafo RDFLib resultante do ``parse`` do arquivo.
+    """
+
+    fmt = "xml" if path.endswith((".owl", ".rdf", ".xml")) else "turtle"
+    g = Graph()
+    g.parse(path, format=fmt)
+    return g

--- a/tests/test_as_rdflib_graph.py
+++ b/tests/test_as_rdflib_graph.py
@@ -1,0 +1,23 @@
+from rdflib import Graph, URIRef
+from rdflib.namespace import RDF, OWL
+
+from ontology.as_rdflib_graph import as_rdflib_graph
+
+
+def test_as_rdflib_graph_loads_ttl(tmp_path):
+    ttl = tmp_path / "mini.ttl"
+    ttl.write_text(
+        """\
+@prefix : <http://ex.org/stream#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+
+:Item rdf:type owl:Class .
+""",
+        encoding="utf-8",
+    )
+
+    g = as_rdflib_graph(str(ttl))
+    assert isinstance(g, Graph)
+    uri = URIRef("http://ex.org/stream#Item")
+    assert (uri, RDF.type, OWL.Class) in g


### PR DESCRIPTION
## Summary
- implement `as_rdflib_graph` to load TTL or OWL files
- add unit test for the new loader

## Testing
- `black --check ontology/as_rdflib_graph.py tests/test_as_rdflib_graph.py`
- `flake8 ontology/as_rdflib_graph.py tests/test_as_rdflib_graph.py`
- `pytest tests/test_as_rdflib_graph.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68701f9b07f0832885a43912f59845f8