### PR TITLE
Improve README with usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,52 @@
 # SIN5033-Grafos-de-Conhecimento-e-Ontologias
-Repository for the final work of the recommendation system using concepts studied in the elcture.
 
-## Requirements
+Este repositório implementa um sistema de recomendação de filmes baseado em grafos de conhecimento. A ontologia descreve usuários, filmes e seus relacionamentos e é enriquecida com inferências OWL RL. Sobre este grafo são executadas consultas SPARQL para recomendações baseadas em conteúdo e cálculos de métricas de serendipidade para reranqueamento das sugestões.
 
-The application relies on Streamlit 1.18 or newer. Install dependencies with:
+## Estrutura dos pacotes
+
+- `ontology/` &ndash; carregamento da ontologia e inferência com `owlrl`.
+- `content_recommender/` &ndash; consultas SPARQL para recomendações por preferência.
+- `collaborative_recommender/` &ndash; wrapper simples em Python para filtros colaborativos (`SurpriseRS`).
+- `serendipity/` &ndash; cálculo de métricas de grafo (centralidade, distância etc.).
+- `pipeline/` &ndash; orquestração do fluxo de recomendação e reranqueamento.
+- `interface/` e `streamlit_app.py` &ndash; interface web em Streamlit.
+- `app.py` &ndash; pequena demonstração em Flask.
+
+## Fluxo de recomendação
+
+1. `build_ontology_graph()` carrega o arquivo OWL/TTL e aplica deduções OWL RL.
+2. `query_by_preference()` extrai candidatos que casam com as preferências declaradas pelo usuário.
+3. `SurpriseRS` estima relevância colaborativa a partir dos ratings.
+4. Métricas em `serendipity/` calculam novidade em um grafo de vizinhança.
+5. `pipeline.engine.rerank()` combina relevância e novidade para produzir a lista final.
+
+## Executando a aplicação
+
+Instale as dependências uma vez:
 
 ```bash
 pip install -r requirements.txt
 ```
+
+Interface Streamlit:
+
+```bash
+streamlit run streamlit_app.py
+```
+
+Demonstrador Flask:
+
+```bash
+python app.py
+```
+
+## Executando os testes
+
+Rode as ferramentas de estilo e a suíte de testes:
+
+```bash
+black --check .
+flake8 .
+pytest --maxfail=1 --disable-warnings -q
+```
+


### PR DESCRIPTION
## Summary
- add overall project description
- document ontology flow and package purposes
- explain Streamlit/Flask launch commands
- add instructions for lint and test commands

## Testing
- `black --check .`
- `flake8 .`
- `pytest --maxfail=1 --disable-warnings -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68701f9d86488328be7b6720a1245e28