### PR TITLE
Centralize base URIs

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,6 +7,8 @@ import requests
 from flask import Flask, render_template, request
 from rdflib import Graph, URIRef
 
+from src.base_uri import EX_BASE
+
 from ontology.build_ontology import build_ontology_graph
 from pipeline.generate_logical_recommendations import recommend_logical
 from pipeline.generate_recommendations import generate_recommendations
@@ -39,9 +41,9 @@ def load_graph(path: str = DATA_PATH) -> Graph:
 
 def load_catalog() -> pd.DataFrame:
     """Lista todos os filmes presentes no grafo global."""
-    query = """
-    PREFIX ex: <http://ex.org/stream#>
-    SELECT DISTINCT ?f WHERE { ?f a ex:Filme . }
+    query = f"""
+    PREFIX ex: <{EX_BASE}>
+    SELECT DISTINCT ?f WHERE {{ ?f a ex:Filme . }}
     """
     uris = [str(r.f) for r in graph.query(query)]
     return pd.DataFrame({"uri": uris})

--- a/content_recommender/query_by_preference.py
+++ b/content_recommender/query_by_preference.py
@@ -2,6 +2,8 @@
 from rdflib import Graph
 from typing import List
 
+from src.base_uri import AMAZING_BASE
+
 
 def query_by_preference(rdf_graph: Graph, user_uri: str) -> List[str]:
     """
@@ -17,7 +19,7 @@ def query_by_preference(rdf_graph: Graph, user_uri: str) -> List[str]:
     rdf_graph : Graph
         Grafo inferido por build_ontology_graph().
     user_uri : str
-        URI completa do usuário (e.g. "http://amazingvideo.org#Usuario123").
+        URI completa do usuário (e.g. f"{AMAZING_BASE}Usuario123").
 
     Retorna
     -------
@@ -26,7 +28,7 @@ def query_by_preference(rdf_graph: Graph, user_uri: str) -> List[str]:
     """
     # --- complete com SPARQL + UNION ---
     sparql = f"""
-    PREFIX : <http://amazingvideo.org#>
+    PREFIX : <{AMAZING_BASE}>
 
     SELECT DISTINCT ?filme WHERE {{
       {{ <{user_uri}> :prefereTematica ?t .

--- a/ontology/build_ontology.py
+++ b/ontology/build_ontology.py
@@ -5,6 +5,8 @@ from rdflib.namespace import RDF, OWL
 from owlrl import DeductiveClosure, OWLRL_Semantics
 import gzip
 
+from src.base_uri import EX_BASE
+
 
 def load_ontology(path: str) -> Graph:
     """
@@ -20,11 +22,10 @@ def load_ontology(path: str) -> Graph:
     fmt = "xml" if path.endswith((".owl", ".rdf", ".xml")) else "turtle"
     g.parse(path, format=fmt)
 
-    base = "http://ex.org/stream#"
     required = {
-        "Video": URIRef(base + "Video"),
-        "Usuario": URIRef(base + "Usuario"),
-        "Genero": URIRef(base + "Genero"),
+        "Video": URIRef(EX_BASE + "Video"),
+        "Usuario": URIRef(EX_BASE + "Usuario"),
+        "Genero": URIRef(EX_BASE + "Genero"),
     }
 
     # Aqui mudamos a verificação:

--- a/pipeline/generate_logical_recommendations.py
+++ b/pipeline/generate_logical_recommendations.py
@@ -4,6 +4,8 @@ from typing import List
 from rdflib import Graph
 import gzip
 
+from src.base_uri import EX_BASE
+
 
 def _load_graph(path: str) -> Graph:
     """Carrega um grafo RDF do caminho fornecido."""
@@ -40,7 +42,7 @@ def recommend_logical(
     """
     graph = _load_graph(ontology_path)
     query = f"""
-    PREFIX ex: <http://ex.org/stream#>
+    PREFIX ex: <{EX_BASE}>
     PREFIX prop: <http://www.wikidata.org/prop/direct/>
     SELECT DISTINCT ?rec WHERE {{
       VALUES ?p {{ prop:P136 prop:P57 prop:P161 }}

--- a/pipeline/generate_recommendations.py
+++ b/pipeline/generate_recommendations.py
@@ -12,14 +12,13 @@ from ontology.build_ontology import build_ontology_graph
 
 from content_recommender.query_by_preference import query_by_preference
 from collaborative_recommender.surprise_rs import SurpriseRS
+from src.base_uri import EX_BASE
 
 # from serendipity.distance import compute_avg_shortest_path_length
 from serendipity.centrality import compute_betweenness
 from .engine import rerank
 
 import networkx as nx
-
-BASE = "http://ex.org/stream#"
 
 
 def _build_graph(rdf_graph: Graph) -> nx.Graph:
@@ -90,16 +89,16 @@ def generate_recommendations(
     # 2. Seleciona candidatos via content-based (SPARQL)
     #    usando as preferências do usuário na ontologia inferida
 
-    user_uri = BASE + str(user_id)
+    user_uri = EX_BASE + str(user_id)
     # retorna lista de local-names, ex: ["videoA","videoB"]
     candidate_names = query_by_preference(rdf_graph, user_uri)
     # converte de volta para URIRefs
-    candidates = [URIRef(BASE + name) for name in candidate_names]
+    candidates = [URIRef(EX_BASE + name) for name in candidate_names]
 
     # (Opcional) Se não houver candidato por filtro de conteúdo,
     # pode-se cair em todos os filmes:
     if not candidates:
-        video_class = URIRef(BASE + "Filme")
+        video_class = URIRef(EX_BASE + "Filme")
         triples = rdf_graph.triples((None, RDF.type, video_class))
         candidates = [subj for subj, _, _ in triples]
 
@@ -107,7 +106,7 @@ def generate_recommendations(
     rs = SurpriseRS()
     # converte itens de ratings para URIRefs para compatibilidade
     ratings_uri = {
-        (u, URIRef(BASE + i) if not isinstance(i, URIRef) else i): r
+        (u, URIRef(EX_BASE + i) if not isinstance(i, URIRef) else i): r
         for (u, i), r in ratings.items()
     }
     rs.fit(ratings_uri)

--- a/scripts/fetch_linkedmdb.py
+++ b/scripts/fetch_linkedmdb.py
@@ -16,8 +16,10 @@ from pathlib import Path
 from rdflib import Graph
 from SPARQLWrapper import SPARQLWrapper, TURTLE
 
+from src.base_uri import EX_BASE
+
 ENDPOINT = "http://data.linkedmdb.org/sparql"
-BASE = "http://ex.org/stream#"
+BASE = EX_BASE
 OUT_PATH = Path("data/raw/linkedmdb_ex.ttl")
 
 

--- a/src/base_uri.py
+++ b/src/base_uri.py
@@ -1,0 +1,7 @@
+"""Constantes de URIs base usadas no projeto."""
+
+EX_BASE = "http://ex.org/stream#"
+"""URI base para recursos e propriedades de exemplo."""
+
+AMAZING_BASE = "http://amazingvideo.org#"
+"""URI base para testes e consultas em ``content_recommender``."""

--- a/src/recommender/graph_builder.py
+++ b/src/recommender/graph_builder.py
@@ -4,6 +4,8 @@
 from rdflib import Graph, URIRef
 import networkx as nx
 
+from src.base_uri import EX_BASE
+
 
 def build_graph(rdf_graph: Graph) -> nx.Graph:
     """
@@ -12,8 +14,8 @@ def build_graph(rdf_graph: Graph) -> nx.Graph:
     Deve:
       1. Iterar sobre triplas ``(s, p, o)`` em ``rdf_graph``;
       2. Para cada tripla onde ``p`` seja
-         ``http://ex.org/stream#assiste`` ou
-         ``http://ex.org/stream#pertenceAGenero``, adicionar nós para ``s``
+         ``EX_BASE + 'assiste'`` ou
+         ``EX_BASE + 'pertenceAGenero'``, adicionar nós para ``s``
          e ``o`` e uma aresta ``(s, o)``;
       3. Retornar o grafo ``networkx`` resultante.
     """
@@ -21,8 +23,8 @@ def build_graph(rdf_graph: Graph) -> nx.Graph:
     grafo = nx.Graph()
 
     predicates = [
-        URIRef("http://ex.org/stream#assiste"),
-        URIRef("http://ex.org/stream#pertenceAGenero"),
+        URIRef(EX_BASE + "assiste"),
+        URIRef(EX_BASE + "pertenceAGenero"),
     ]
 
     for predicate_uri in predicates:

--- a/src/recommender/pipeline.py
+++ b/src/recommender/pipeline.py
@@ -8,8 +8,7 @@ from .graph_builder import build_graph
 from serendipity.distance import compute_avg_shortest_path_length
 from .recommenders.surprise_rs import SurpriseRS
 from .engine import rerank
-
-BASE = "http://ex.org/stream#"
+from src.base_uri import EX_BASE
 
 
 def generate_recommendations(
@@ -30,7 +29,7 @@ def generate_recommendations(
 
     # 3. Identifica apenas as instâncias de vídeo
     #    (filtrando por rdf:type :Video)
-    video_class = URIRef(BASE + "Video")
+    video_class = URIRef(EX_BASE + "Video")
     video_nodes = [
         subj for subj, _, _ in rdf_graph.triples((None, RDF.type, video_class))
     ]

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -6,6 +6,8 @@ import requests
 import streamlit as st
 from rdflib import Graph, URIRef
 
+from src.base_uri import EX_BASE
+
 from ontology.build_ontology import build_ontology_graph
 from pipeline.generate_logical_recommendations import recommend_logical
 from pipeline.generate_recommendations import generate_recommendations
@@ -40,9 +42,9 @@ def load_catalog() -> pd.DataFrame:
     Observação: prefixamos o parâmetro com _ para que o Streamlit
     não tente hashear o objeto Graph.
     """
-    query = """
-    PREFIX ex: <http://ex.org/stream#>
-    SELECT DISTINCT ?f WHERE { ?f a ex:Filme . }
+    query = f"""
+    PREFIX ex: <{EX_BASE}>
+    SELECT DISTINCT ?f WHERE {{ ?f a ex:Filme . }}
     """
     # usa o grafo global _graph
     uris = [str(r.f) for r in _graph.query(query)]

--- a/tests/test_build_ontology.py
+++ b/tests/test_build_ontology.py
@@ -1,14 +1,15 @@
 from rdflib import URIRef
 from rdflib.namespace import RDF
 from ontology.build_ontology import build_ontology_graph
+from src.base_uri import EX_BASE
 
 
 def test_infers_subclasses_via_owlrl(tmp_path):
     # 1. Cria um OWL simples com rdfs:subClassOf
     owl = tmp_path / "test.owl"
     owl.write_text(
-        """
-    @prefix : <http://ex.org/stream#> .
+        f"""
+    @prefix : <{EX_BASE}> .
     @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 
     :Filme        a rdfs:Class .
@@ -22,6 +23,6 @@ def test_infers_subclasses_via_owlrl(tmp_path):
     g = build_ontology_graph(str(owl))
 
     # 3. Deve ter inferido: doc1 rdf:type Filme
-    doc1 = URIRef("http://ex.org/stream#doc1")
-    filme = URIRef("http://ex.org/stream#Filme")
+    doc1 = URIRef(EX_BASE + "doc1")
+    filme = URIRef(EX_BASE + "Filme")
     assert any(g.triples((doc1, RDF.type, filme)))

--- a/tests/test_fetch_linkedmdb.py
+++ b/tests/test_fetch_linkedmdb.py
@@ -1,7 +1,8 @@
 from rdflib import Graph, URIRef
 from rdflib.namespace import RDF
+from src.base_uri import EX_BASE
 
-BASE = "http://ex.org/stream#"
+BASE = EX_BASE
 
 
 def test_linkedmdb_contains_filme():

--- a/tests/test_flask_app.py
+++ b/tests/test_flask_app.py
@@ -2,6 +2,7 @@ import importlib.util
 import pathlib
 
 from rdflib import Graph
+from src.base_uri import EX_BASE
 
 MODULE_PATH = pathlib.Path(__file__).resolve().parents[1] / "app.py"
 spec = importlib.util.spec_from_file_location("flask_app", MODULE_PATH)
@@ -13,8 +14,8 @@ exec(code, module.__dict__)
 load_graph = module.load_graph
 load_catalog = module.load_catalog
 
-TTL = """
-@prefix ex: <http://ex.org/stream#> .
+TTL = f"""
+@prefix ex: <{EX_BASE}> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
 ex:f1 a ex:Filme .
@@ -32,8 +33,8 @@ def test_load_graph_and_catalog(tmp_path):
 
     assert isinstance(g, Graph)
     assert set(df["uri"]) == {
-        "http://ex.org/stream#f1",
-        "http://ex.org/stream#f2",
+        EX_BASE + "f1",
+        EX_BASE + "f2",
     }
 
 

--- a/tests/test_generate_logical_recommendations.py
+++ b/tests/test_generate_logical_recommendations.py
@@ -1,8 +1,9 @@
 import pytest
 from pipeline.generate_logical_recommendations import recommend_logical
+from src.base_uri import EX_BASE
 
-TTL = """
-@prefix ex: <http://ex.org/stream#> .
+TTL = f"""
+@prefix ex: <{EX_BASE}> .
 @prefix prop: <http://www.wikidata.org/prop/direct/> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
@@ -22,12 +23,12 @@ def test_recommend_logical_basic(tmp_path):
     f.write_text(TTL)
 
     recs = recommend_logical(
-        "http://ex.org/stream#f1",
+        EX_BASE + "f1",
         ontology_path=str(f),
         top_n=5,
     )
-    assert "http://ex.org/stream#f2" in recs
-    assert "http://ex.org/stream#f1" not in recs
+    assert EX_BASE + "f2" in recs
+    assert EX_BASE + "f1" not in recs
 
 
 def test_recommend_logical_no_match(tmp_path):
@@ -35,7 +36,7 @@ def test_recommend_logical_no_match(tmp_path):
     f.write_text(TTL)
 
     recs = recommend_logical(
-        "http://ex.org/stream#f3",
+        EX_BASE + "f3",
         ontology_path=str(f),
         top_n=5,
     )
@@ -45,6 +46,6 @@ def test_recommend_logical_no_match(tmp_path):
 def test_recommend_logical_invalid_path():
     with pytest.raises(Exception):
         recommend_logical(
-            "http://ex.org/stream#f1",
+            EX_BASE + "f1",
             ontology_path="no_file.ttl",
         )

--- a/tests/test_graph_builder.py
+++ b/tests/test_graph_builder.py
@@ -3,11 +3,12 @@ from rdflib import URIRef
 import networkx as nx
 
 from src.recommender.graph_builder import build_graph
+from src.base_uri import EX_BASE
 
-BASE = "http://ex.org/stream#"
+BASE = EX_BASE
 
-TEST_TTL = """\
-@prefix : <http://ex.org/stream#> .
+TEST_TTL = f"""\
+@prefix : <{BASE}> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 

--- a/tests/test_ontology_loader.py
+++ b/tests/test_ontology_loader.py
@@ -3,14 +3,15 @@ from rdflib import Graph, URIRef
 from rdflib.namespace import RDF, OWL
 
 from ontology.build_ontology import load_ontology
+from src.base_uri import EX_BASE
 
 
 def test_load_valid_ontology(tmp_path):
     # 1. Cria um arquivo TTL mínimo
     ttl = tmp_path / "test_ontology.ttl"
     ttl.write_text(
-        """\
-@prefix : <http://ex.org/stream#> .
+        f"""\
+@prefix : <{EX_BASE}> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 
@@ -25,7 +26,7 @@ def test_load_valid_ontology(tmp_path):
     assert isinstance(g, Graph)
 
     # 3. Verifica cada classe
-    base = "http://ex.org/stream#"
+    base = EX_BASE
     for cls in ("Video", "Usuario", "Genero"):
         uri = URIRef(base + cls)
         assert any(
@@ -37,8 +38,8 @@ def test_load_invalid_ontology(tmp_path):
     # 1. Cria um TTL sem a classe Genero
     ttl = tmp_path / "bad_ontology.ttl"
     ttl.write_text(
-        """\
-@prefix : <http://ex.org/stream#> .
+        f"""\
+@prefix : <{EX_BASE}> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,8 +1,9 @@
 from pipeline.generate_recommendations import generate_recommendations
+from src.base_uri import EX_BASE
 
-BASE = "http://ex.org/stream#"
-TTL = """\
-@prefix : <http://ex.org/stream#> .
+BASE = EX_BASE
+TTL = f"""\
+@prefix : <{BASE}> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -2,11 +2,12 @@
 
 from collaborative_recommender.surprise_rs import SurpriseRS
 from pipeline.generate_recommendations import generate_recommendations
+from src.base_uri import EX_BASE
 
-BASE = "http://ex.org/stream#"
+BASE = EX_BASE
 
-TTL = """\
-@prefix : <http://ex.org/stream#> .
+TTL = f"""\
+@prefix : <{BASE}> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 

--- a/tests/test_query_by_preference.py
+++ b/tests/test_query_by_preference.py
@@ -1,10 +1,11 @@
 from rdflib import Graph
 from content_recommender.query_by_preference import query_by_preference
+from src.base_uri import AMAZING_BASE
 
-BASE = "http://amazingvideo.org#"
+BASE = AMAZING_BASE
 
-TTL = """\
-@prefix : <http://amazingvideo.org#> .
+TTL = f"""\
+@prefix : <{BASE}> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 # Usuário com 3 tipos de preferência

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -1,5 +1,6 @@
 import pytest
 from rdflib import Graph
+from src.base_uri import EX_BASE
 
 import importlib.util
 import pathlib
@@ -14,8 +15,8 @@ exec(code, module.__dict__)
 load_graph = module.load_graph
 load_catalog = module.load_catalog
 
-TTL = """
-@prefix ex: <http://ex.org/stream#> .
+TTL = f"""
+@prefix ex: <{EX_BASE}> .
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 
 ex:f1 a ex:Filme .
@@ -36,8 +37,8 @@ def test_load_graph_and_catalog(tmp_path):
     # Assert
     assert isinstance(g, Graph)
     assert set(df["uri"]) == {
-        "http://ex.org/stream#f1",
-        "http://ex.org/stream#f2",
+        EX_BASE + "f1",
+        EX_BASE + "f2",
     }
 
 


### PR DESCRIPTION
## Summary
- add `src/base_uri.py` with EX_BASE and AMAZING_BASE constants
- refactor modules to import these constants
- update SPARQL queries to use formatted base URIs
- adjust tests accordingly

## Testing
- `black --check .`
- `flake8 .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68701fa7a6a483288f87a9f66b9c0a00