### PR TITLE
Add RDF graph reuse in recommenders

### DIFF
--- a/interface/streamlit_app.py
+++ b/interface/streamlit_app.py
@@ -150,7 +150,7 @@ if selected:
         st.write("**Elenco:**", ", ".join(details["cast"]) or "N/A")
 
     st.subheader("Você pode gostar também de…")
-    recs_log = recommend_logical(selected, DATA_PATH)
+    recs_log = recommend_logical(selected, DATA_PATH, rdf_graph=_graph)
     cols = st.columns(len(recs_log))
     for col, uri in zip(cols, recs_log):
         img = fetch_image(uri)
@@ -164,6 +164,7 @@ if selected:
         top_n=5,
         alpha=1.0,
         beta=0.0,
+        rdf_graph=_graph,
     )
     cols = st.columns(len(recs_ser))
     for col, qid in zip(cols, recs_ser):

--- a/pipeline/generate_logical_recommendations.py
+++ b/pipeline/generate_logical_recommendations.py
@@ -21,6 +21,7 @@ def recommend_logical(
     uri: str,
     ontology_path: str,
     top_n: int = 5,
+    rdf_graph: Graph | None = None,
 ) -> List[str]:
     """Retorna filmes logicamente relacionados.
 
@@ -33,12 +34,16 @@ def recommend_logical(
     top_n : int
         Número máximo de recomendações.
 
+    rdf_graph : Graph | None, optional
+        Grafo RDF pré-carregado. Se ``None``, o grafo será lido de
+        ``ontology_path``.
+
     Returns
     -------
     List[str]
         URIs de filmes recomendados.
     """
-    graph = _load_graph(ontology_path)
+    graph = rdf_graph if rdf_graph is not None else _load_graph(ontology_path)
     query = f"""
     PREFIX ex: <http://ex.org/stream#>
     PREFIX prop: <http://www.wikidata.org/prop/direct/>

--- a/pipeline/generate_recommendations.py
+++ b/pipeline/generate_recommendations.py
@@ -58,6 +58,7 @@ def generate_recommendations(
     alpha: float = 0.5,
     beta: float = 0.5,
     novelty_metric: str = "betweenness",
+    rdf_graph: Graph | None = None,
 ) -> List[str]:
     """Gera recomendações híbridas baseadas em conteúdo e colaboração.
 
@@ -78,6 +79,10 @@ def generate_recommendations(
     novelty_metric : str
         Métrica de novidade a ser utilizada.
 
+    rdf_graph : Graph | None, optional
+        Grafo RDF pré-carregado. Se ``None``, o grafo será construído a
+        partir de ``ontology_path``.
+
     Returns
     -------
     List[str]
@@ -85,7 +90,8 @@ def generate_recommendations(
     """
 
     # 1. Carrega o grafo com inferência
-    rdf_graph = build_ontology_graph(ontology_path)
+    if rdf_graph is None:
+        rdf_graph = build_ontology_graph(ontology_path)
 
     # 2. Seleciona candidatos via content-based (SPARQL)
     #    usando as preferências do usuário na ontologia inferida

--- a/tests/test_generate_logical_recommendations.py
+++ b/tests/test_generate_logical_recommendations.py
@@ -1,4 +1,5 @@
 import pytest
+from ontology.build_ontology import build_ontology_graph
 from pipeline.generate_logical_recommendations import recommend_logical
 
 TTL = """
@@ -21,10 +22,12 @@ def test_recommend_logical_basic(tmp_path):
     f = tmp_path / "graph.ttl"
     f.write_text(TTL)
 
+    graph = build_ontology_graph(str(f))
     recs = recommend_logical(
         "http://ex.org/stream#f1",
         ontology_path=str(f),
         top_n=5,
+        rdf_graph=graph,
     )
     assert "http://ex.org/stream#f2" in recs
     assert "http://ex.org/stream#f1" not in recs
@@ -34,10 +37,12 @@ def test_recommend_logical_no_match(tmp_path):
     f = tmp_path / "graph.ttl"
     f.write_text(TTL)
 
+    graph = build_ontology_graph(str(f))
     recs = recommend_logical(
         "http://ex.org/stream#f3",
         ontology_path=str(f),
         top_n=5,
+        rdf_graph=graph,
     )
     assert recs == []
 

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,3 +1,4 @@
+from ontology.build_ontology import build_ontology_graph
 from pipeline.generate_recommendations import generate_recommendations
 
 BASE = "http://ex.org/stream#"
@@ -44,8 +45,15 @@ def test_generate_recommendations_basic(tmp_path, monkeypatch):
         fake_predict,
     )
 
+    graph = build_ontology_graph(str(path))
     recs = generate_recommendations(
-        "user1", ratings, str(path), top_n=2, alpha=1.0, beta=0.0
+        "user1",
+        ratings,
+        str(path),
+        top_n=2,
+        alpha=1.0,
+        beta=0.0,
+        rdf_graph=graph,
     )
 
     assert recs[0] == "videoB"

--- a/tests/test_pipeline_integration.py
+++ b/tests/test_pipeline_integration.py
@@ -1,6 +1,7 @@
 # tests/test_pipeline_integration.py
 
 from collaborative_recommender.surprise_rs import SurpriseRS
+from ontology.build_ontology import build_ontology_graph
 from pipeline.generate_recommendations import generate_recommendations
 
 BASE = "http://ex.org/stream#"
@@ -49,6 +50,7 @@ def test_full_pipeline(tmp_path, monkeypatch):
 
     monkeypatch.setattr(SurpriseRS, "predict", fake_predict)
 
+    graph = build_ontology_graph(str(f))
     # 3. Chamamos o pipeline
     recs = generate_recommendations(
         user_id="user1",
@@ -57,6 +59,7 @@ def test_full_pipeline(tmp_path, monkeypatch):
         top_n=3,
         alpha=1.0,  # só novelty
         beta=0.0,  # ignora relevance
+        rdf_graph=graph,
     )
 
     # 4. Como só novelty conta, videoB (maior distância) vem antes de C

--- a/tests/test_pipeline_integration_real.py
+++ b/tests/test_pipeline_integration_real.py
@@ -1,5 +1,6 @@
 import pytest
 from rdflib import URIRef
+from ontology.build_ontology import build_ontology_graph
 from pipeline.generate_recommendations import generate_recommendations
 
 # teste de integração usando o dump real de filmes
@@ -17,6 +18,7 @@ def test_generate_recommendations_real_dump():
     }
 
     # gera recomendações
+    graph = build_ontology_graph("data/raw/serendipity_films_full.ttl.gz")
     recs = generate_recommendations(
         user_id=user_id,
         ratings=ratings,
@@ -24,6 +26,7 @@ def test_generate_recommendations_real_dump():
         top_n=5,
         alpha=1.0,
         beta=0.0,
+        rdf_graph=graph,
     )
 
     # retorna lista de strings com tamanho 5


### PR DESCRIPTION
## Summary
- allow passing a preloaded `Graph` to `generate_recommendations`
- allow passing a preloaded `Graph` to `recommend_logical`
- pass cached graph in `interface/streamlit_app.py`
- adapt tests to cover calls using provided graphs

## Testing
- `black --check .`
- `flake8 .`
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_68702d4a15fc8328bd5eddaf8241a2ae