### PR TITLE
Add user-based recommender flow

### DIFF
--- a/data/demo_users.json
+++ b/data/demo_users.json
@@ -1,0 +1,4 @@
+{
+  "user1": {"videoA": 5.0, "videoB": 3.0},
+  "user2": {"videoB": 4.5, "videoC": 2.0}
+}

--- a/tests/test_flask_app.py
+++ b/tests/test_flask_app.py
@@ -3,9 +3,7 @@ import pathlib
 
 from rdflib import Graph
 
-MODULE_PATH = (
-    pathlib.Path(__file__).resolve().parents[1] / "interface" / "app.py"
-)
+MODULE_PATH = pathlib.Path(__file__).resolve().parents[1] / "interface" / "app.py"
 spec = importlib.util.spec_from_file_location("flask_app", MODULE_PATH)
 module = importlib.util.module_from_spec(spec)
 with open(MODULE_PATH, "r", encoding="utf-8") as fh:

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -5,9 +5,7 @@ import importlib.util
 import pathlib
 
 MODULE_PATH = (
-    pathlib.Path(__file__).resolve().parents[1]
-    / "interface"
-    / "streamlit_app.py"
+    pathlib.Path(__file__).resolve().parents[1] / "interface" / "streamlit_app.py"
 )
 spec = importlib.util.spec_from_file_location("_app", MODULE_PATH)
 module = importlib.util.module_from_spec(spec)

--- a/tests/test_streamlit_user.py
+++ b/tests/test_streamlit_user.py
@@ -1,0 +1,72 @@
+import importlib.util
+import pathlib
+
+import pytest
+
+MODULE_PATH = (
+    pathlib.Path(__file__).resolve().parents[1] / "interface" / "streamlit_app.py"
+)
+spec = importlib.util.spec_from_file_location("_app", MODULE_PATH)
+module = importlib.util.module_from_spec(spec)
+with open(MODULE_PATH, "r", encoding="utf-8") as fh:
+    code = fh.read().split("# --- Configuração inicial ---", maxsplit=1)[0]
+exec(code, module.__dict__)
+
+load_users = module.load_users
+generate_recommendations = module.generate_recommendations
+
+TTL = """\
+@prefix : <http://ex.org/stream#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+:Usuario   a rdf:Class .
+:Filme     a rdf:Class .
+:Tematica  a rdf:Class .
+:acao      a :Tematica .
+:Drama     a :Tematica .
+:Spielberg a rdf:Resource .
+
+:user1 a :Usuario ;
+       :prefereTematica :acao ;
+       :prefereDiretor  :Spielberg .
+
+:videoA a :Filme ;
+        :tematica    :acao ;
+        :dirigidoPor :Spielberg .
+:videoB a :Filme ;
+        :tematica    :Drama ;
+        :dirigidoPor :Spielberg .
+"""
+
+
+def test_load_users(tmp_path):
+    j = tmp_path / "u.json"
+    j.write_text('{"user1": {"videoA": 5.0}}', encoding="utf-8")
+
+    users = load_users(path=str(j))
+
+    assert users == {"user1": {"videoA": 5.0}}
+
+
+def test_recommendations_with_user_ratings(tmp_path, monkeypatch):
+    ttl_path = tmp_path / "g.ttl"
+    ttl_path.write_text(TTL, encoding="utf-8")
+    json_path = tmp_path / "u.json"
+    json_path.write_text('{"user1": {"videoA": 5.0}}', encoding="utf-8")
+
+    users = load_users(path=str(json_path))
+    ratings = {("user1", vid): r for vid, r in users["user1"].items()}
+
+    def fake_predict(self, user_id, items):
+        return {item: (0.0 if item == "videoA" else 1.0) for item in items}
+
+    monkeypatch.setattr(
+        "collaborative_recommender.surprise_rs.SurpriseRS.predict", fake_predict
+    )
+
+    recs = generate_recommendations(
+        "user1", ratings, str(ttl_path), top_n=2, alpha=1.0, beta=0.0
+    )
+
+    assert recs == ["videoB", "videoA"]


### PR DESCRIPTION
## Summary
- create a demo fixture with simple user ratings
- extend Streamlit app to choose a user and use their history
- show watched movies in the sidebar
- add tests for loading users and user-based recommendations
- update formatting

## Testing
- `black --check .`
- `flake8 .`
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_68702d6844a08328a020b47a1fdfe319