### PR TITLE
Remove duplicate Streamlit script

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Este repositório implementa um sistema de recomendação de filmes baseado em g
 - `collaborative_recommender/` &ndash; wrapper simples em Python para filtros colaborativos (`SurpriseRS`).
 - `serendipity/` &ndash; cálculo de métricas de grafo (centralidade, distância etc.).
 - `pipeline/` &ndash; orquestração do fluxo de recomendação e reranqueamento.
-- `interface/` e `streamlit_app.py` &ndash; interface web em Streamlit.
+- `interface/streamlit_app.py` &ndash; interface web em Streamlit.
 - `app.py` &ndash; pequena demonstração em Flask.
 
 ## Fluxo de recomendação
@@ -31,7 +31,7 @@ pip install -r requirements.txt
 Interface Streamlit:
 
 ```bash
-streamlit run streamlit_app.py
+streamlit run interface/streamlit_app.py
 ```
 
 Demonstrador Flask:

--- a/tests/test_flask_app.py
+++ b/tests/test_flask_app.py
@@ -3,9 +3,7 @@ import pathlib
 
 from rdflib import Graph
 
-MODULE_PATH = (
-    pathlib.Path(__file__).resolve().parents[1] / "interface" / "app.py"
-)
+MODULE_PATH = pathlib.Path(__file__).resolve().parents[1] / "interface" / "app.py"
 spec = importlib.util.spec_from_file_location("flask_app", MODULE_PATH)
 module = importlib.util.module_from_spec(spec)
 with open(MODULE_PATH, "r", encoding="utf-8") as fh:

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -5,9 +5,7 @@ import importlib.util
 import pathlib
 
 MODULE_PATH = (
-    pathlib.Path(__file__).resolve().parents[1]
-    / "interface"
-    / "streamlit_app.py"
+    pathlib.Path(__file__).resolve().parents[1] / "interface" / "streamlit_app.py"
 )
 spec = importlib.util.spec_from_file_location("_app", MODULE_PATH)
 module = importlib.util.module_from_spec(spec)


### PR DESCRIPTION
## Summary
- drop empty placeholder under `streamlit_app/`
- document correct path for launching Streamlit
- reformat tests with `black`

## Testing
- `black --check .`
- `flake8 .`
- `pytest --maxfail=1 --disable-warnings -q` *(fails: KeyboardInterrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68702d71c4948328892b5c193416ec55