### PR TITLE
Add module docstrings and fix tests formatting

### DIFF
--- a/ontology/__init__.py
+++ b/ontology/__init__.py
@@ -1,0 +1,1 @@
+"""Pacote com utilidades de ontologia e inferência OWL RL."""

--- a/ontology/build_ontology.py
+++ b/ontology/build_ontology.py
@@ -1,4 +1,4 @@
-# src/recommender/ontology_loader.py
+"""Utilidades para carregamento e inferência de ontologias."""
 
 from rdflib import Graph, URIRef
 from rdflib.namespace import RDF, OWL
@@ -7,14 +7,23 @@ import gzip
 
 
 def load_ontology(path: str) -> Graph:
-    """
-    path: caminho para arquivo .ttl ou .owl
-    retorna: um RDFLib Graph com todos os axiomas carregados
+    """Carrega e valida uma ontologia.
+
+    Parameters
+    ----------
+    path : str
+        Caminho para arquivo ``.ttl`` ou ``.owl``.
+
+    Returns
+    -------
+    Graph
+        Grafo carregado com axiomas explícitos.
 
     Raises
     ------
     ValueError
-        Se :Video, :Usuario ou :Genero não estiverem definidos como classes.
+        Se ``:Video``, ``:Usuario`` ou ``:Genero`` não estiverem
+        definidos como classes.
     """
     g = Graph()
     fmt = "xml" if path.endswith((".owl", ".rdf", ".xml")) else "turtle"
@@ -37,9 +46,18 @@ def load_ontology(path: str) -> Graph:
 
 
 def build_ontology_graph(ontology_path: str) -> Graph:
-    """
-    Carrega uma ontologia (TTL, OWL ou TTL.GZ), executa inferências OWL RL
-    e retorna um rdflib.Graph com axiomas explícitos e inferidos.
+    """Executa inferência OWL RL e retorna o grafo completo.
+
+    Parameters
+    ----------
+    ontology_path : str
+        Caminho para o arquivo de ontologia. Pode ser ``.ttl``, ``.owl`` ou
+        versões compactadas ``.gz``.
+
+    Returns
+    -------
+    Graph
+        Grafo com axiomas explícitos e inferidos.
     """
     g = Graph()
 

--- a/pipeline/__init__.py
+++ b/pipeline/__init__.py
@@ -1,0 +1,1 @@
+"""Módulos para orquestração da recomendação."""

--- a/pipeline/engine.py
+++ b/pipeline/engine.py
@@ -1,5 +1,4 @@
-# arquivo: src/recommender/engine.py
-# Python 3
+"""Rotinas de reordenação para recomendações."""
 
 from typing import List, Dict, Any
 
@@ -15,7 +14,7 @@ def rerank(
     Reordena uma lista de candidatos por serendipidade:
       score(item) = alpha * novelty[item] + beta * relevance[item]
 
-    Parametros
+    Parâmetros
     ----------
     candidates : List[Any]
         Itens a serem rankeados.

--- a/pipeline/generate_logical_recommendations.py
+++ b/pipeline/generate_logical_recommendations.py
@@ -1,3 +1,5 @@
+"""Geração de recomendações por lógica de descrição."""
+
 from __future__ import annotations
 
 from typing import List
@@ -6,7 +8,18 @@ import gzip
 
 
 def _load_graph(path: str) -> Graph:
-    """Carrega um grafo RDF do caminho fornecido."""
+    """Carrega um grafo RDF.
+
+    Parameters
+    ----------
+    path : str
+        Caminho para o arquivo do grafo, opcionalmente compactado.
+
+    Returns
+    -------
+    Graph
+        Instância carregada de ``rdflib.Graph``.
+    """
     g = Graph()
     if path.endswith(".gz"):
         with gzip.open(path, "rt", encoding="utf-8") as f:

--- a/tests/test_flask_app.py
+++ b/tests/test_flask_app.py
@@ -3,9 +3,7 @@ import pathlib
 
 from rdflib import Graph
 
-MODULE_PATH = (
-    pathlib.Path(__file__).resolve().parents[1] / "interface" / "app.py"
-)
+MODULE_PATH = pathlib.Path(__file__).resolve().parents[1] / "interface" / "app.py"
 spec = importlib.util.spec_from_file_location("flask_app", MODULE_PATH)
 module = importlib.util.module_from_spec(spec)
 with open(MODULE_PATH, "r", encoding="utf-8") as fh:

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -5,9 +5,7 @@ import importlib.util
 import pathlib
 
 MODULE_PATH = (
-    pathlib.Path(__file__).resolve().parents[1]
-    / "interface"
-    / "streamlit_app.py"
+    pathlib.Path(__file__).resolve().parents[1] / "interface" / "streamlit_app.py"
 )
 spec = importlib.util.spec_from_file_location("_app", MODULE_PATH)
 module = importlib.util.module_from_spec(spec)


### PR DESCRIPTION
## Summary
- add missing package docstrings for `ontology` and `pipeline`
- document ontology utilities with NumPy-style docstrings
- document recommendation pipeline modules
- reformat long lines in test files

## Testing
- `black --check .`
- `flake8 .`
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_68702d8112c08328a51c73e50b5a1ef1