### PR TITLE
Add ontology reuse tests

### DIFF
--- a/pipeline/generate_logical_recommendations.py
+++ b/pipeline/generate_logical_recommendations.py
@@ -21,6 +21,7 @@ def recommend_logical(
     uri: str,
     ontology_path: str,
     top_n: int = 5,
+    rdf_graph: Graph | None = None,
 ) -> List[str]:
     """Retorna filmes logicamente relacionados.
 
@@ -30,6 +31,8 @@ def recommend_logical(
         URI do filme de referência.
     ontology_path : str
         Caminho para o dump de filmes.
+    rdf_graph : Graph, optional
+        Grafo já carregado para reutilização.
     top_n : int
         Número máximo de recomendações.
 
@@ -38,7 +41,7 @@ def recommend_logical(
     List[str]
         URIs de filmes recomendados.
     """
-    graph = _load_graph(ontology_path)
+    graph = rdf_graph if rdf_graph is not None else _load_graph(ontology_path)
     query = f"""
     PREFIX ex: <http://ex.org/stream#>
     PREFIX prop: <http://www.wikidata.org/prop/direct/>

--- a/pipeline/generate_recommendations.py
+++ b/pipeline/generate_recommendations.py
@@ -58,6 +58,7 @@ def generate_recommendations(
     alpha: float = 0.5,
     beta: float = 0.5,
     novelty_metric: str = "betweenness",
+    rdf_graph: Graph | None = None,
 ) -> List[str]:
     """Gera recomendações híbridas baseadas em conteúdo e colaboração.
 
@@ -69,6 +70,8 @@ def generate_recommendations(
         Avaliações conhecidas.
     ontology_path : str
         Caminho para o arquivo de ontologia.
+    rdf_graph : Graph, optional
+        Grafo já inferido para reutilização.
     top_n : int
         Número máximo de itens retornados.
     alpha : float
@@ -84,8 +87,14 @@ def generate_recommendations(
         Lista de identificadores de vídeo.
     """
 
-    # 1. Carrega o grafo com inferência
-    rdf_graph = build_ontology_graph(ontology_path)
+    # 1. Carrega o grafo com inferência (opcionalmente reutiliza existente)
+    # fmt: off
+    rdf_graph = (
+        rdf_graph
+        if rdf_graph is not None
+        else build_ontology_graph(ontology_path)
+    )
+    # fmt: on
 
     # 2. Seleciona candidatos via content-based (SPARQL)
     #    usando as preferências do usuário na ontologia inferida

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,89 @@
+from rdflib import Graph
+
+from pipeline.generate_logical_recommendations import recommend_logical
+from pipeline.generate_recommendations import generate_recommendations
+from ontology.build_ontology import build_ontology_graph
+
+TTL_LOGICAL = """\
+@prefix ex: <http://ex.org/stream#> .
+@prefix prop: <http://www.wikidata.org/prop/direct/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+
+ex:f1 a ex:Filme ;
+    prop:P136 ex:g1 ;
+    prop:P57 ex:d1 .
+ex:f2 a ex:Filme ;
+    prop:P136 ex:g1 ;
+    prop:P57 ex:d1 .
+"""
+
+TTL_PIPELINE = """\
+@prefix : <http://ex.org/stream#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+
+:Usuario   a rdf:Class .
+:Filme     a rdf:Class .
+:Tematica  a rdf:Class .
+:acao      a :Tematica .
+:Spielberg a rdf:Resource .
+
+:user1 a :Usuario ;
+       :prefereTematica :acao ;
+       :prefereDiretor  :Spielberg .
+
+:videoA a :Filme ;
+        :tematica    :acao ;
+        :dirigidoPor :Spielberg .
+"""
+
+
+def test_recommend_logical_reuses_graph(monkeypatch):
+    g = Graph()
+    g.parse(data=TTL_LOGICAL, format="turtle")
+    calls = {"count": 0}
+
+    def fake_loader(path: str) -> Graph:
+        calls["count"] += 1
+        return g
+
+    monkeypatch.setattr(
+        "pipeline.generate_logical_recommendations._load_graph", fake_loader
+    )
+
+    recommend_logical("http://ex.org/stream#f1", "dummy.ttl", rdf_graph=g)
+    recommend_logical("http://ex.org/stream#f1", "dummy.ttl", rdf_graph=g)
+
+    assert calls["count"] == 0
+
+
+def test_generate_recommendations_reuses_graph(tmp_path, monkeypatch):
+    path = tmp_path / "g.ttl"
+    path.write_text(TTL_PIPELINE)
+    g = build_ontology_graph(str(path))
+
+    loader_calls = {"count": 0}
+
+    def fake_loader(p: str) -> Graph:
+        loader_calls["count"] += 1
+        return g
+
+    monkeypatch.setattr(
+        "ontology.build_ontology.build_ontology_graph",
+        fake_loader,
+    )
+
+    def fake_predict(self, user_id, items):
+        return {item: 1.0 for item in items}
+
+    monkeypatch.setattr(
+        "collaborative_recommender.surprise_rs.SurpriseRS.predict",
+        fake_predict,
+    )
+
+    ratings = {("user1", "videoA"): 5.0}
+
+    generate_recommendations("user1", ratings, str(path), top_n=1, rdf_graph=g)
+    generate_recommendations("user1", ratings, str(path), top_n=1, rdf_graph=g)
+
+    assert loader_calls["count"] == 0

--- a/tests/test_flask_app.py
+++ b/tests/test_flask_app.py
@@ -3,9 +3,13 @@ import pathlib
 
 from rdflib import Graph
 
+# fmt: off
 MODULE_PATH = (
-    pathlib.Path(__file__).resolve().parents[1] / "interface" / "app.py"
+    pathlib.Path(__file__).resolve().parents[1]
+    / "interface"
+    / "app.py"
 )
+# fmt: on
 spec = importlib.util.spec_from_file_location("flask_app", MODULE_PATH)
 module = importlib.util.module_from_spec(spec)
 with open(MODULE_PATH, "r", encoding="utf-8") as fh:

--- a/tests/test_streamlit_app.py
+++ b/tests/test_streamlit_app.py
@@ -4,11 +4,13 @@ from rdflib import Graph
 import importlib.util
 import pathlib
 
+# fmt: off
 MODULE_PATH = (
     pathlib.Path(__file__).resolve().parents[1]
     / "interface"
     / "streamlit_app.py"
 )
+# fmt: on
 spec = importlib.util.spec_from_file_location("_app", MODULE_PATH)
 module = importlib.util.module_from_spec(spec)
 with open(MODULE_PATH, "r", encoding="utf-8") as fh:


### PR DESCRIPTION
## Summary
- avoid reloading the ontology in `recommend_logical` and `generate_recommendations`
- test reuse of RDF graphs for logical and hybrid recommenders
- keep import paths below flake8 line length

## Testing
- `black --check .`
- `flake8 .`
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_68702d856ed08328aafedb7590808f55